### PR TITLE
Add a few speedups for v. small eff. loss

### DIFF
--- a/nanoAOD/plugins/HadronProducer.cc
+++ b/nanoAOD/plugins/HadronProducer.cc
@@ -424,7 +424,7 @@ vector<HadronProducer::hadronCandidate> HadronProducer::findJPsiCands(vector<rec
 						hc.dca, hc.angleXY, hc.angleXYZ);
 
       if (cand.numberOfDaughters() < 2) continue;
-      if (abs(cand.mass() - jpsi_m_) > 0.2) continue;
+      if (fabs(cand.mass() - jpsi_m_) > 0.3) continue;
       
       hc.vcc = cand;
       hc.jet = aPatJet;
@@ -466,7 +466,7 @@ vector<HadronProducer::hadronCandidate> HadronProducer::findD0Cands(vector<reco:
 						hc.dca, hc.angleXY, hc.angleXYZ);
 
       if (cand.numberOfDaughters() < 2) continue;
-      if (abs(cand.mass() - d0_m_) > 0.2) continue;
+      if (fabs(cand.mass() - d0_m_) > 0.2) continue;
       
       hc.vcc = cand;
       hc.jet = aPatJet;
@@ -525,7 +525,7 @@ vector<HadronProducer::hadronCandidate> HadronProducer::findDStarCands(vector<Ha
       if (cand.numberOfDaughters() < 2) continue;
       
       float diffMass_Dstar = cand.mass() - d0.vcc.mass();      
-      if (abs(diffMass_Dstar - (dstar_m_ - d0_m_)) > 0.2) continue;
+      if (fabs(diffMass_Dstar - (dstar_m_ - d0_m_)) > 0.2) continue;
       
       hc.vcc = cand;
       hc.jet = aPatJet;
@@ -670,7 +670,7 @@ vector<HadronProducer::hadronCandidate> HadronProducer::findLambdaBCands(vector<
       reco::VertexCompositeCandidate cand(0, tlv, jpsi.vcc.vertex(), jpsi.vcc.vertexCovariance(), jpsi.vcc.vertexChi2(), jpsi.vcc.vertexNdof(), (lambda.vcc.pdgId() > 0) ? lambdab_pdgId_ : -lambdab_pdgId_);
 
       // if (cand.numberOfDaughters() < 2) continue;
-      if (abs(cand.mass() - lambdab_m_) > 0.4) continue;
+      if (fabs(cand.mass() - lambdab_m_) > 0.4) continue;
      
       cand.addDaughter(lambda.vcc);
       cand.addDaughter(jpsi.vcc);          


### PR DESCRIPTION
I've been playing around with this, and I can get the code to run in ~ 2/3 the time of previously (i.e. if it took 3 days before, it should take 2 with this, based on igprof profile of ~ 10 miniaods files) for basically no eff. loss (< 1%). Cuts would be needed to reduce this further. D0/D*/ jpsi/lambdab takes almost no time, so we can just look at Ks/Lambda (with Lambda taking more time overall).

The changes are:

- Require dipion/proton-pion mass prefit be vaguely in range of Ks/Lam
- static KalmanVertexFitter (i.e. create only once rather than per fit)
- make auto loops use references
- proton pt cut for lambda

In NanoAOD tests, HadronProducer goes from taking half the time, to
20% of the total time.