### PR TITLE
Split Event_2016v4.h to three things(Event_2016v4.h , HadEvents, HadT…

### DIFF
--- a/analysis/bin/BuildFile.xml
+++ b/analysis/bin/BuildFile.xml
@@ -32,3 +32,4 @@
   <use name="nano/analysis"/>
   <flags CXXFLAGS="-g" />
 </bin>
+

--- a/analysis/bin/slCalibAnalysis.cc
+++ b/analysis/bin/slCalibAnalysis.cc
@@ -47,9 +47,9 @@ void slCalibAnalysis::Loop() {
 			     << (hadt ? hadt->GetCurrentFile()->GetName() : "")
 			     << endl;
     if (hadt) {
-      if (had.event != event || had.run != run || had.luminosityBlock != luminosityBlock) {
-	std::cout << "Bad sync! " << event << " " << had.event << " " << run << " " << had.run
-		  << " " << luminosityBlock << " " << had.luminosityBlock
+      if (had.ht_event != event || had.ht_run != run || had.ht_luminosityBlock != luminosityBlock) {
+	std::cout << "Bad sync! " << event << " " << had.ht_event << " " << run << " " << had.ht_run
+		  << " " << luminosityBlock << " " << had.ht_luminosityBlock
 		  << std::endl;
 	exit(1);
       }

--- a/analysis/interface/Events_2016v4.h
+++ b/analysis/interface/Events_2016v4.h
@@ -119,41 +119,6 @@ public :
    Int_t           GenVisTau_genPartIdxMother[5];   //[nGenVisTau]
    Int_t           GenVisTau_status[5];   //[nGenVisTau]
    Float_t         genWeight;
-   UInt_t          nhad_jet;
-   Float_t         had_jet_btagCMVA[1100];   //[nhad_jet]
-   Float_t         had_jet_btagCSVV2[1100];   //[nhad_jet]
-   Float_t         had_jet_btagDeepB[1100];   //[nhad_jet]
-   Float_t         had_jet_btagDeepC[1100];   //[nhad_jet]
-   Float_t         had_jet_eta[1100];   //[nhad_jet]
-   Float_t         had_jet_mass[1100];   //[nhad_jet]
-   Float_t         had_jet_phi[1100];   //[nhad_jet]
-   Float_t         had_jet_pt[1100];   //[nhad_jet]
-   UInt_t          nhad;
-   Float_t         had_jetDR[1100];   //[nhad]
-   Float_t         had_legDR[1100];   //[nhad]
-   Float_t         had_diffMass[1100];   //[nhad]
-   Float_t         had_lxy[1100];   //[nhad]
-   Float_t         had_lxyErr[1100];   //[nhad]
-   Float_t         had_l3D[1100];   //[nhad]
-   Float_t         had_l3DErr[1100];   //[nhad]
-   Float_t         had_dca[1100];   //[nhad]
-   Float_t         had_angleXY[1100];   //[nhad]
-   Float_t         had_angleXYZ[1100];   //[nhad]
-   Float_t         had_dau1_chi2[1100];   //[nhad]
-   Float_t         had_dau1_nHits[1100];   //[nhad]
-   Float_t         had_dau1_pt[1100];   //[nhad]
-   Float_t         had_dau1_ipsigXY[1100];   //[nhad]
-   Float_t         had_dau1_ipsigZ[1100];   //[nhad]
-   Float_t         had_dau2_chi2[1100];   //[nhad]
-   Float_t         had_dau2_nHits[1100];   //[nhad]
-   Float_t         had_dau2_pt[1100];   //[nhad]
-   Float_t         had_dau2_ipsigXY[1100];   //[nhad]
-   Float_t         had_dau2_ipsigZ[1100];   //[nhad]
-   Int_t           had_nJet[1100];   //[nhad]
-   Int_t           had_nDau[1100];   //[nhad]
-   Int_t           had_idx[1100];   //[nhad]
-   Int_t           had_dau1_idx[1100];   //[nhad]
-   Int_t           had_dau2_idx[1100];   //[nhad]
    UInt_t          nJet;
    Float_t         Jet_area[35];   //[nJet]
    Float_t         Jet_btagCMVA[35];   //[nJet]
@@ -350,16 +315,6 @@ public :
    UChar_t         GenJetAK8_hadronFlavour[10];   //[nGenJetAK8]
    Int_t           GenJet_partonFlavour[20];   //[nGenJet]
    UChar_t         GenJet_hadronFlavour[20];   //[nGenJet]
-   Float_t         had_chi2[1100];   //[nhad]
-   Float_t         had_eta[1100];   //[nhad]
-   Float_t         had_mass[1100];   //[nhad]
-   Float_t         had_phi[1100];   //[nhad]
-   Float_t         had_pt[1100];   //[nhad]
-   Float_t         had_x[1100];   //[nhad]
-   Float_t         had_y[1100];   //[nhad]
-   Float_t         had_z[1100];   //[nhad]
-   Int_t           had_ndof[1100];   //[nhad]
-   Int_t           had_pdgId[1100];   //[nhad]
    Int_t           Jet_genJetIdx[35];   //[nJet]
    Int_t           Jet_hadronFlavour[35];   //[nJet]
    Int_t           Jet_partonFlavour[35];   //[nJet]
@@ -1113,41 +1068,6 @@ public :
    TBranch        *b_GenVisTau_genPartIdxMother;   //!
    TBranch        *b_GenVisTau_status;   //!
    TBranch        *b_genWeight;   //!
-   TBranch        *b_nhad_jet;   //!
-   TBranch        *b_had_jet_btagCMVA;   //!
-   TBranch        *b_had_jet_btagCSVV2;   //!
-   TBranch        *b_had_jet_btagDeepB;   //!
-   TBranch        *b_had_jet_btagDeepC;   //!
-   TBranch        *b_had_jet_eta;   //!
-   TBranch        *b_had_jet_mass;   //!
-   TBranch        *b_had_jet_phi;   //!
-   TBranch        *b_had_jet_pt;   //!
-   TBranch        *b_nhad;   //!
-   TBranch        *b_had_jetDR;   //!
-   TBranch        *b_had_legDR;   //!
-   TBranch        *b_had_diffMass;   //!
-   TBranch        *b_had_lxy;   //!
-   TBranch        *b_had_lxyErr;   //!
-   TBranch        *b_had_l3D;   //!
-   TBranch        *b_had_l3DErr;   //!
-   TBranch        *b_had_dca;   //!
-   TBranch        *b_had_angleXY;   //!
-   TBranch        *b_had_angleXYZ;   //!
-   TBranch        *b_had_dau1_chi2;   //!
-   TBranch        *b_had_dau1_nHits;   //!
-   TBranch        *b_had_dau1_pt;   //!
-   TBranch        *b_had_dau1_ipsigXY;   //!
-   TBranch        *b_had_dau1_ipsigZ;   //!
-   TBranch        *b_had_dau2_chi2;   //!
-   TBranch        *b_had_dau2_nHits;   //!
-   TBranch        *b_had_dau2_pt;   //!
-   TBranch        *b_had_dau2_ipsigXY;   //!
-   TBranch        *b_had_dau2_ipsigZ;   //!
-   TBranch        *b_had_nJet;   //!
-   TBranch        *b_had_nDau;   //!
-   TBranch        *b_had_idx;   //!
-   TBranch        *b_had_dau1_idx;   //!
-   TBranch        *b_had_dau2_idx;   //!
    TBranch        *b_nJet;   //!
    TBranch        *b_Jet_area;   //!
    TBranch        *b_Jet_btagCMVA;   //!
@@ -1343,16 +1263,6 @@ public :
    TBranch        *b_GenJetAK8_hadronFlavour;   //!
    TBranch        *b_GenJet_partonFlavour;   //!
    TBranch        *b_GenJet_hadronFlavour;   //!
-   TBranch        *b_had_chi2;   //!
-   TBranch        *b_had_eta;   //!
-   TBranch        *b_had_mass;   //!
-   TBranch        *b_had_phi;   //!
-   TBranch        *b_had_pt;   //!
-   TBranch        *b_had_x;   //!
-   TBranch        *b_had_y;   //!
-   TBranch        *b_had_z;   //!
-   TBranch        *b_had_ndof;   //!
-   TBranch        *b_had_pdgId;   //!
    TBranch        *b_Jet_genJetIdx;   //!
    TBranch        *b_Jet_hadronFlavour;   //!
    TBranch        *b_Jet_partonFlavour;   //!
@@ -2175,41 +2085,6 @@ void Events::Init(TTree *tree)
    fChain->SetBranchAddress("GenVisTau_genPartIdxMother", GenVisTau_genPartIdxMother, &b_GenVisTau_genPartIdxMother);
    fChain->SetBranchAddress("GenVisTau_status", GenVisTau_status, &b_GenVisTau_status);
    fChain->SetBranchAddress("genWeight", &genWeight, &b_genWeight);
-   fChain->SetBranchAddress("nhad_jet", &nhad_jet, &b_nhad_jet);
-   fChain->SetBranchAddress("had_jet_btagCMVA", had_jet_btagCMVA, &b_had_jet_btagCMVA);
-   fChain->SetBranchAddress("had_jet_btagCSVV2", had_jet_btagCSVV2, &b_had_jet_btagCSVV2);
-   fChain->SetBranchAddress("had_jet_btagDeepB", had_jet_btagDeepB, &b_had_jet_btagDeepB);
-   fChain->SetBranchAddress("had_jet_btagDeepC", had_jet_btagDeepC, &b_had_jet_btagDeepC);
-   fChain->SetBranchAddress("had_jet_eta", had_jet_eta, &b_had_jet_eta);
-   fChain->SetBranchAddress("had_jet_mass", had_jet_mass, &b_had_jet_mass);
-   fChain->SetBranchAddress("had_jet_phi", had_jet_phi, &b_had_jet_phi);
-   fChain->SetBranchAddress("had_jet_pt", had_jet_pt, &b_had_jet_pt);
-   fChain->SetBranchAddress("nhad", &nhad, &b_nhad);
-   fChain->SetBranchAddress("had_jetDR", had_jetDR, &b_had_jetDR);
-   fChain->SetBranchAddress("had_legDR", had_legDR, &b_had_legDR);
-   fChain->SetBranchAddress("had_diffMass", had_diffMass, &b_had_diffMass);
-   fChain->SetBranchAddress("had_lxy", had_lxy, &b_had_lxy);
-   fChain->SetBranchAddress("had_lxyErr", had_lxyErr, &b_had_lxyErr);
-   fChain->SetBranchAddress("had_l3D", had_l3D, &b_had_l3D);
-   fChain->SetBranchAddress("had_l3DErr", had_l3DErr, &b_had_l3DErr);
-   fChain->SetBranchAddress("had_dca", had_dca, &b_had_dca);
-   fChain->SetBranchAddress("had_angleXY", had_angleXY, &b_had_angleXY);
-   fChain->SetBranchAddress("had_angleXYZ", had_angleXYZ, &b_had_angleXYZ);
-   fChain->SetBranchAddress("had_dau1_chi2", had_dau1_chi2, &b_had_dau1_chi2);
-   fChain->SetBranchAddress("had_dau1_nHits", had_dau1_nHits, &b_had_dau1_nHits);
-   fChain->SetBranchAddress("had_dau1_pt", had_dau1_pt, &b_had_dau1_pt);
-   fChain->SetBranchAddress("had_dau1_ipsigXY", had_dau1_ipsigXY, &b_had_dau1_ipsigXY);
-   fChain->SetBranchAddress("had_dau1_ipsigZ", had_dau1_ipsigZ, &b_had_dau1_ipsigZ);
-   fChain->SetBranchAddress("had_dau2_chi2", had_dau2_chi2, &b_had_dau2_chi2);
-   fChain->SetBranchAddress("had_dau2_nHits", had_dau2_nHits, &b_had_dau2_nHits);
-   fChain->SetBranchAddress("had_dau2_pt", had_dau2_pt, &b_had_dau2_pt);
-   fChain->SetBranchAddress("had_dau2_ipsigXY", had_dau2_ipsigXY, &b_had_dau2_ipsigXY);
-   fChain->SetBranchAddress("had_dau2_ipsigZ", had_dau2_ipsigZ, &b_had_dau2_ipsigZ);
-   fChain->SetBranchAddress("had_nJet", had_nJet, &b_had_nJet);
-   fChain->SetBranchAddress("had_nDau", had_nDau, &b_had_nDau);
-   fChain->SetBranchAddress("had_idx", had_idx, &b_had_idx);
-   fChain->SetBranchAddress("had_dau1_idx", had_dau1_idx, &b_had_dau1_idx);
-   fChain->SetBranchAddress("had_dau2_idx", had_dau2_idx, &b_had_dau2_idx);
    fChain->SetBranchAddress("nJet", &nJet, &b_nJet);
    fChain->SetBranchAddress("Jet_area", Jet_area, &b_Jet_area);
    fChain->SetBranchAddress("Jet_btagCMVA", Jet_btagCMVA, &b_Jet_btagCMVA);
@@ -2405,16 +2280,6 @@ void Events::Init(TTree *tree)
    fChain->SetBranchAddress("GenJetAK8_hadronFlavour", GenJetAK8_hadronFlavour, &b_GenJetAK8_hadronFlavour);
    fChain->SetBranchAddress("GenJet_partonFlavour", GenJet_partonFlavour, &b_GenJet_partonFlavour);
    fChain->SetBranchAddress("GenJet_hadronFlavour", GenJet_hadronFlavour, &b_GenJet_hadronFlavour);
-   fChain->SetBranchAddress("had_chi2", had_chi2, &b_had_chi2);
-   fChain->SetBranchAddress("had_eta", had_eta, &b_had_eta);
-   fChain->SetBranchAddress("had_mass", had_mass, &b_had_mass);
-   fChain->SetBranchAddress("had_phi", had_phi, &b_had_phi);
-   fChain->SetBranchAddress("had_pt", had_pt, &b_had_pt);
-   fChain->SetBranchAddress("had_x", had_x, &b_had_x);
-   fChain->SetBranchAddress("had_y", had_y, &b_had_y);
-   fChain->SetBranchAddress("had_z", had_z, &b_had_z);
-   fChain->SetBranchAddress("had_ndof", had_ndof, &b_had_ndof);
-   fChain->SetBranchAddress("had_pdgId", had_pdgId, &b_had_pdgId);
    fChain->SetBranchAddress("Jet_genJetIdx", Jet_genJetIdx, &b_Jet_genJetIdx);
    fChain->SetBranchAddress("Jet_hadronFlavour", Jet_hadronFlavour, &b_Jet_hadronFlavour);
    fChain->SetBranchAddress("Jet_partonFlavour", Jet_partonFlavour, &b_Jet_partonFlavour);

--- a/analysis/interface/HadTruthEvents.h
+++ b/analysis/interface/HadTruthEvents.h
@@ -15,16 +15,27 @@
 // Header file for the classes stored in the TTree if any.
 
 class HadTruthEvents {
+private :
+   virtual Int_t    Cut(Long64_t entry);
+   virtual Int_t    GetEntry(Long64_t entry);
+
+   virtual Long64_t ht_LoadTree(Long64_t entry);
+//   virtual void     Init(TTree *tree);
+
+   virtual Bool_t   Notify();
+   virtual void     Show(Long64_t entry = -1);
+
 public :
-   TTree          *fChain;   //!pointer to the analyzed TTree or TChain
+   TTree          *ht_fChain;   //!pointer to the analyzed TTree or TChain
    Int_t           fCurrent; //!current Tree number in a TChain
 
 // Fixed size dimensions of array or collections stored in the TTree if any.
 
    // Declaration of leaf types
-   UInt_t          run;
-   UInt_t          luminosityBlock;
-   ULong64_t       event;
+   UInt_t          ht_run;
+   UInt_t          ht_luminosityBlock;
+   ULong64_t       ht_event;
+/*
    UInt_t          nGenPart;
    Float_t         GenPart_eta[5000];   //[nGenPart]
    Float_t         GenPart_mass[5000];   //[nGenPart]
@@ -89,6 +100,7 @@ public :
    UChar_t         genHadron_inVol[50];   //[ngenHadron]
    UChar_t         genHadron_isMatching[50];   //[ngenHadron]
    UChar_t         genHadron_isMatched[50];   //[ngenHadron]
+*/
    UInt_t          nhadTruth;
    Int_t           hadTruth_nMatched[250];   //[nhadTruth]
    Int_t           hadTruth_nTrueDau[250];   //[nhadTruth]
@@ -98,6 +110,7 @@ public :
    UChar_t         hadTruth_isHadFromS[250];   //[nhadTruth]
    UChar_t         hadTruth_isHadFromC[250];   //[nhadTruth]
    UChar_t         hadTruth_isHadFromB[250];   //[nhadTruth]
+/*
    UInt_t          nOtherPV;
    Float_t         OtherPV_z[5];   //[nOtherPV]
    Float_t         PV_ndof;
@@ -760,11 +773,13 @@ public :
    Bool_t          Flag_trkPOG_toomanystripclus53X;
    Bool_t          Flag_trkPOG_logErrorTooManyClusters;
    Bool_t          Flag_METFilters;
+*/
 
    // List of branches
-   TBranch        *b_run;   //!
-   TBranch        *b_luminosityBlock;   //!
-   TBranch        *b_event;   //!
+   TBranch        *b_ht_run;   //!
+   TBranch        *b_ht_luminosityBlock;   //!
+   TBranch        *b_ht_event;   //!
+/*
    TBranch        *b_nGenPart;   //!
    TBranch        *b_GenPart_eta;   //!
    TBranch        *b_GenPart_mass;   //!
@@ -829,6 +844,7 @@ public :
    TBranch        *b_genHadron_inVol;   //!
    TBranch        *b_genHadron_isMatching;   //!
    TBranch        *b_genHadron_isMatched;   //!
+*/
    TBranch        *b_nhadTruth;   //!
    TBranch        *b_hadTruth_nMatched;   //!
    TBranch        *b_hadTruth_nTrueDau;   //!
@@ -838,6 +854,7 @@ public :
    TBranch        *b_hadTruth_isHadFromS;   //!
    TBranch        *b_hadTruth_isHadFromC;   //!
    TBranch        *b_hadTruth_isHadFromB;   //!
+/*
    TBranch        *b_nOtherPV;   //!
    TBranch        *b_OtherPV_z;   //!
    TBranch        *b_PV_ndof;   //!
@@ -1500,22 +1517,22 @@ public :
    TBranch        *b_Flag_trkPOG_toomanystripclus53X;   //!
    TBranch        *b_Flag_trkPOG_logErrorTooManyClusters;   //!
    TBranch        *b_Flag_METFilters;   //!
-
+*/
    HadTruthEvents(TTree *tree=0);
    virtual ~HadTruthEvents();
-   virtual Int_t    Cut(Long64_t entry);
-   virtual Int_t    GetEntry(Long64_t entry);
-   virtual Long64_t LoadTree(Long64_t entry);
+//   virtual Int_t    Cut(Long64_t entry);
+//   virtual Int_t    GetEntry(Long64_t entry);
+//   virtual Long64_t LoadTree(Long64_t entry);
    virtual void     Init(TTree *tree);
-   virtual void     Loop();
-   virtual Bool_t   Notify();
-   virtual void     Show(Long64_t entry = -1);
+//   virtual void     Loop();
+//   virtual Bool_t   Notify();
+//   virtual void     Show(Long64_t entry = -1);
 };
 
 #endif
 
 #ifdef HadTruthEvents_cxx
-HadTruthEvents::HadTruthEvents(TTree *tree) : fChain(0) 
+HadTruthEvents::HadTruthEvents(TTree *tree) : ht_fChain(0) 
 {
 // if parameter tree is not specified (or zero), connect the file
 // used to generate this class and read the Tree.
@@ -1532,24 +1549,24 @@ HadTruthEvents::HadTruthEvents(TTree *tree) : fChain(0)
 
 HadTruthEvents::~HadTruthEvents()
 {
-   if (!fChain) return;
-   delete fChain->GetCurrentFile();
+   if (!ht_fChain) return;
+   delete ht_fChain->GetCurrentFile();
 }
 
 Int_t HadTruthEvents::GetEntry(Long64_t entry)
 {
 // Read contents of entry.
-   if (!fChain) return 0;
-   return fChain->GetEntry(entry);
+   if (!ht_fChain) return 0;
+   return ht_fChain->GetEntry(entry);
 }
-Long64_t HadTruthEvents::LoadTree(Long64_t entry)
+Long64_t HadTruthEvents::ht_LoadTree(Long64_t entry)
 {
 // Set the environment to read one entry
-   if (!fChain) return -5;
-   Long64_t centry = fChain->LoadTree(entry);
+   if (!ht_fChain) return -5;
+   Long64_t centry = ht_fChain->LoadTree(entry);
    if (centry < 0) return centry;
-   if (fChain->GetTreeNumber() != fCurrent) {
-      fCurrent = fChain->GetTreeNumber();
+   if (ht_fChain->GetTreeNumber() != fCurrent) {
+      fCurrent = ht_fChain->GetTreeNumber();
       Notify();
    }
    return centry;
@@ -1567,119 +1584,123 @@ void HadTruthEvents::Init(TTree *tree)
 
    // Set branch addresses and branch pointers
    if (!tree) return;
-   fChain = tree;
+   ht_fChain = tree;
    fCurrent = -1;
-   fChain->SetMakeClass(1);
+   ht_fChain->SetMakeClass(1);
 
-   fChain->SetBranchAddress("run", &run, &b_run);
-   fChain->SetBranchAddress("luminosityBlock", &luminosityBlock, &b_luminosityBlock);
-   fChain->SetBranchAddress("event", &event, &b_event);
-   fChain->SetBranchAddress("nGenPart", &nGenPart, &b_nGenPart);
-   fChain->SetBranchAddress("GenPart_eta", GenPart_eta, &b_GenPart_eta);
-   fChain->SetBranchAddress("GenPart_mass", GenPart_mass, &b_GenPart_mass);
-   fChain->SetBranchAddress("GenPart_phi", GenPart_phi, &b_GenPart_phi);
-   fChain->SetBranchAddress("GenPart_pt", GenPart_pt, &b_GenPart_pt);
-   fChain->SetBranchAddress("GenPart_genPartIdxMother", GenPart_genPartIdxMother, &b_GenPart_genPartIdxMother);
-   fChain->SetBranchAddress("GenPart_pdgId", GenPart_pdgId, &b_GenPart_pdgId);
-   fChain->SetBranchAddress("GenPart_status", GenPart_status, &b_GenPart_status);
-   fChain->SetBranchAddress("GenPart_statusFlags", GenPart_statusFlags, &b_GenPart_statusFlags);
-   fChain->SetBranchAddress("nhad_jet", &nhad_jet, &b_nhad_jet);
-   fChain->SetBranchAddress("had_jet_btagCMVA", had_jet_btagCMVA, &b_had_jet_btagCMVA);
-   fChain->SetBranchAddress("had_jet_btagCSVV2", had_jet_btagCSVV2, &b_had_jet_btagCSVV2);
-   fChain->SetBranchAddress("had_jet_btagDeepB", had_jet_btagDeepB, &b_had_jet_btagDeepB);
-   fChain->SetBranchAddress("had_jet_btagDeepC", had_jet_btagDeepC, &b_had_jet_btagDeepC);
-   fChain->SetBranchAddress("had_jet_eta", had_jet_eta, &b_had_jet_eta);
-   fChain->SetBranchAddress("had_jet_mass", had_jet_mass, &b_had_jet_mass);
-   fChain->SetBranchAddress("had_jet_phi", had_jet_phi, &b_had_jet_phi);
-   fChain->SetBranchAddress("had_jet_pt", had_jet_pt, &b_had_jet_pt);
-   fChain->SetBranchAddress("nhad", &nhad, &b_nhad);
-   fChain->SetBranchAddress("had_jetDR", had_jetDR, &b_had_jetDR);
-   fChain->SetBranchAddress("had_legDR", had_legDR, &b_had_legDR);
-   fChain->SetBranchAddress("had_diffMass", had_diffMass, &b_had_diffMass);
-   fChain->SetBranchAddress("had_lxy", had_lxy, &b_had_lxy);
-   fChain->SetBranchAddress("had_lxyErr", had_lxyErr, &b_had_lxyErr);
-   fChain->SetBranchAddress("had_l3D", had_l3D, &b_had_l3D);
-   fChain->SetBranchAddress("had_l3DErr", had_l3DErr, &b_had_l3DErr);
-   fChain->SetBranchAddress("had_dca", had_dca, &b_had_dca);
-   fChain->SetBranchAddress("had_angleXY", had_angleXY, &b_had_angleXY);
-   fChain->SetBranchAddress("had_angleXYZ", had_angleXYZ, &b_had_angleXYZ);
-   fChain->SetBranchAddress("had_dau1_chi2", had_dau1_chi2, &b_had_dau1_chi2);
-   fChain->SetBranchAddress("had_dau1_nHits", had_dau1_nHits, &b_had_dau1_nHits);
-   fChain->SetBranchAddress("had_dau1_pt", had_dau1_pt, &b_had_dau1_pt);
-   fChain->SetBranchAddress("had_dau1_ipsigXY", had_dau1_ipsigXY, &b_had_dau1_ipsigXY);
-   fChain->SetBranchAddress("had_dau1_ipsigZ", had_dau1_ipsigZ, &b_had_dau1_ipsigZ);
-   fChain->SetBranchAddress("had_dau2_chi2", had_dau2_chi2, &b_had_dau2_chi2);
-   fChain->SetBranchAddress("had_dau2_nHits", had_dau2_nHits, &b_had_dau2_nHits);
-   fChain->SetBranchAddress("had_dau2_pt", had_dau2_pt, &b_had_dau2_pt);
-   fChain->SetBranchAddress("had_dau2_ipsigXY", had_dau2_ipsigXY, &b_had_dau2_ipsigXY);
-   fChain->SetBranchAddress("had_dau2_ipsigZ", had_dau2_ipsigZ, &b_had_dau2_ipsigZ);
-   fChain->SetBranchAddress("had_nJet", had_nJet, &b_had_nJet);
-   fChain->SetBranchAddress("had_nDau", had_nDau, &b_had_nDau);
-   fChain->SetBranchAddress("had_dau1_charge", had_dau1_charge, &b_had_dau1_charge);
-   fChain->SetBranchAddress("had_dau2_charge", had_dau2_charge, &b_had_dau2_charge);
-   fChain->SetBranchAddress("had_idx", had_idx, &b_had_idx);
-   fChain->SetBranchAddress("had_dau1_idx", had_dau1_idx, &b_had_dau1_idx);
-   fChain->SetBranchAddress("had_dau2_idx", had_dau2_idx, &b_had_dau2_idx);
-   fChain->SetBranchAddress("ngenHadron", &ngenHadron, &b_ngenHadron);
-   fChain->SetBranchAddress("genHadron_dau1_pt", genHadron_dau1_pt, &b_genHadron_dau1_pt);
-   fChain->SetBranchAddress("genHadron_dau2_pt", genHadron_dau2_pt, &b_genHadron_dau2_pt);
-   fChain->SetBranchAddress("genHadron_dau1_eta", genHadron_dau1_eta, &b_genHadron_dau1_eta);
-   fChain->SetBranchAddress("genHadron_dau2_eta", genHadron_dau2_eta, &b_genHadron_dau2_eta);
-   fChain->SetBranchAddress("genHadron_dau1_phi", genHadron_dau1_phi, &b_genHadron_dau1_phi);
-   fChain->SetBranchAddress("genHadron_dau2_phi", genHadron_dau2_phi, &b_genHadron_dau2_phi);
-   fChain->SetBranchAddress("genHadron_vx", genHadron_vx, &b_genHadron_vx);
-   fChain->SetBranchAddress("genHadron_vy", genHadron_vy, &b_genHadron_vy);
-   fChain->SetBranchAddress("genHadron_vz", genHadron_vz, &b_genHadron_vz);
-   fChain->SetBranchAddress("genHadron_isGenHadFromTsb", genHadron_isGenHadFromTsb, &b_genHadron_isGenHadFromTsb);
-   fChain->SetBranchAddress("genHadron_dau1_pdgId", genHadron_dau1_pdgId, &b_genHadron_dau1_pdgId);
-   fChain->SetBranchAddress("genHadron_dau2_pdgId", genHadron_dau2_pdgId, &b_genHadron_dau2_pdgId);
-   fChain->SetBranchAddress("genHadron_isGenParticle", genHadron_isGenParticle, &b_genHadron_isGenParticle);
-   fChain->SetBranchAddress("genHadron_isGenHadFromTop", genHadron_isGenHadFromTop, &b_genHadron_isGenHadFromTop);
-   fChain->SetBranchAddress("genHadron_inVol", genHadron_inVol, &b_genHadron_inVol);
-   fChain->SetBranchAddress("genHadron_isMatching", genHadron_isMatching, &b_genHadron_isMatching);
-   fChain->SetBranchAddress("genHadron_isMatched", genHadron_isMatched, &b_genHadron_isMatched);
-   fChain->SetBranchAddress("nhadTruth", &nhadTruth, &b_nhadTruth);
-   fChain->SetBranchAddress("hadTruth_nMatched", hadTruth_nMatched, &b_hadTruth_nMatched);
-   fChain->SetBranchAddress("hadTruth_nTrueDau", hadTruth_nTrueDau, &b_hadTruth_nTrueDau);
-   fChain->SetBranchAddress("hadTruth_isHadFromTsb", hadTruth_isHadFromTsb, &b_hadTruth_isHadFromTsb);
-   fChain->SetBranchAddress("hadTruth_isHadFromTop", hadTruth_isHadFromTop, &b_hadTruth_isHadFromTop);
-   fChain->SetBranchAddress("hadTruth_isHadFromW", hadTruth_isHadFromW, &b_hadTruth_isHadFromW);
-   fChain->SetBranchAddress("hadTruth_isHadFromS", hadTruth_isHadFromS, &b_hadTruth_isHadFromS);
-   fChain->SetBranchAddress("hadTruth_isHadFromC", hadTruth_isHadFromC, &b_hadTruth_isHadFromC);
-   fChain->SetBranchAddress("hadTruth_isHadFromB", hadTruth_isHadFromB, &b_hadTruth_isHadFromB);
-   fChain->SetBranchAddress("nOtherPV", &nOtherPV, &b_nOtherPV);
-   fChain->SetBranchAddress("OtherPV_z", OtherPV_z, &b_OtherPV_z);
-   fChain->SetBranchAddress("PV_ndof", &PV_ndof, &b_PV_ndof);
-   fChain->SetBranchAddress("PV_x", &PV_x, &b_PV_x);
-   fChain->SetBranchAddress("PV_y", &PV_y, &b_PV_y);
-   fChain->SetBranchAddress("PV_z", &PV_z, &b_PV_z);
-   fChain->SetBranchAddress("PV_chi2", &PV_chi2, &b_PV_chi2);
-   fChain->SetBranchAddress("PV_score", &PV_score, &b_PV_score);
-   fChain->SetBranchAddress("PV_npvs", &PV_npvs, &b_PV_npvs);
-   fChain->SetBranchAddress("PV_npvsGood", &PV_npvsGood, &b_PV_npvsGood);
-   fChain->SetBranchAddress("nSV", &nSV, &b_nSV);
-   fChain->SetBranchAddress("SV_dlen", SV_dlen, &b_SV_dlen);
-   fChain->SetBranchAddress("SV_dlenSig", SV_dlenSig, &b_SV_dlenSig);
-   fChain->SetBranchAddress("SV_pAngle", SV_pAngle, &b_SV_pAngle);
-   fChain->SetBranchAddress("had_chi2", had_chi2, &b_had_chi2);
-   fChain->SetBranchAddress("had_eta", had_eta, &b_had_eta);
-   fChain->SetBranchAddress("had_mass", had_mass, &b_had_mass);
-   fChain->SetBranchAddress("had_phi", had_phi, &b_had_phi);
-   fChain->SetBranchAddress("had_pt", had_pt, &b_had_pt);
-   fChain->SetBranchAddress("had_x", had_x, &b_had_x);
-   fChain->SetBranchAddress("had_y", had_y, &b_had_y);
-   fChain->SetBranchAddress("had_z", had_z, &b_had_z);
-   fChain->SetBranchAddress("had_ndof", had_ndof, &b_had_ndof);
-   fChain->SetBranchAddress("had_pdgId", had_pdgId, &b_had_pdgId);
-   fChain->SetBranchAddress("genHadron_eta", genHadron_eta, &b_genHadron_eta);
-   fChain->SetBranchAddress("genHadron_mass", genHadron_mass, &b_genHadron_mass);
-   fChain->SetBranchAddress("genHadron_phi", genHadron_phi, &b_genHadron_phi);
-   fChain->SetBranchAddress("genHadron_pt", genHadron_pt, &b_genHadron_pt);
-   fChain->SetBranchAddress("genHadron_x", genHadron_x, &b_genHadron_x);
-   fChain->SetBranchAddress("genHadron_y", genHadron_y, &b_genHadron_y);
-   fChain->SetBranchAddress("genHadron_z", genHadron_z, &b_genHadron_z);
-   fChain->SetBranchAddress("genHadron_pdgId", genHadron_pdgId, &b_genHadron_pdgId);
-   fChain->SetBranchAddress("L1simulation_step", &L1simulation_step, &b_L1simulation_step);
+   ht_fChain->SetBranchAddress("run", &ht_run, &b_ht_run);
+   ht_fChain->SetBranchAddress("luminosityBlock", &ht_luminosityBlock, &b_ht_luminosityBlock);
+   ht_fChain->SetBranchAddress("event", &ht_event, &b_ht_event);
+/*
+   ht_fChain->SetBranchAddress("nGenPart", &nGenPart, &b_nGenPart);
+   ht_fChain->SetBranchAddress("GenPart_eta", GenPart_eta, &b_GenPart_eta);
+   ht_fChain->SetBranchAddress("GenPart_mass", GenPart_mass, &b_GenPart_mass);
+   ht_fChain->SetBranchAddress("GenPart_phi", GenPart_phi, &b_GenPart_phi);
+   ht_fChain->SetBranchAddress("GenPart_pt", GenPart_pt, &b_GenPart_pt);
+   ht_fChain->SetBranchAddress("GenPart_genPartIdxMother", GenPart_genPartIdxMother, &b_GenPart_genPartIdxMother);
+   ht_fChain->SetBranchAddress("GenPart_pdgId", GenPart_pdgId, &b_GenPart_pdgId);
+   ht_fChain->SetBranchAddress("GenPart_status", GenPart_status, &b_GenPart_status);
+   ht_fChain->SetBranchAddress("GenPart_statusFlags", GenPart_statusFlags, &b_GenPart_statusFlags);
+   ht_fChain->SetBranchAddress("nhad_jet", &nhad_jet, &b_nhad_jet);
+   ht_fChain->SetBranchAddress("had_jet_btagCMVA", had_jet_btagCMVA, &b_had_jet_btagCMVA);
+   ht_fChain->SetBranchAddress("had_jet_btagCSVV2", had_jet_btagCSVV2, &b_had_jet_btagCSVV2);
+   ht_fChain->SetBranchAddress("had_jet_btagDeepB", had_jet_btagDeepB, &b_had_jet_btagDeepB);
+   ht_fChain->SetBranchAddress("had_jet_btagDeepC", had_jet_btagDeepC, &b_had_jet_btagDeepC);
+   ht_fChain->SetBranchAddress("had_jet_eta", had_jet_eta, &b_had_jet_eta);
+   ht_fChain->SetBranchAddress("had_jet_mass", had_jet_mass, &b_had_jet_mass);
+   ht_fChain->SetBranchAddress("had_jet_phi", had_jet_phi, &b_had_jet_phi);
+   ht_fChain->SetBranchAddress("had_jet_pt", had_jet_pt, &b_had_jet_pt);
+   ht_fChain->SetBranchAddress("nhad", &nhad, &b_nhad);
+   ht_fChain->SetBranchAddress("had_jetDR", had_jetDR, &b_had_jetDR);
+   ht_fChain->SetBranchAddress("had_legDR", had_legDR, &b_had_legDR);
+   ht_fChain->SetBranchAddress("had_diffMass", had_diffMass, &b_had_diffMass);
+   ht_fChain->SetBranchAddress("had_lxy", had_lxy, &b_had_lxy);
+   ht_fChain->SetBranchAddress("had_lxyErr", had_lxyErr, &b_had_lxyErr);
+   ht_fChain->SetBranchAddress("had_l3D", had_l3D, &b_had_l3D);
+   ht_fChain->SetBranchAddress("had_l3DErr", had_l3DErr, &b_had_l3DErr);
+   ht_fChain->SetBranchAddress("had_dca", had_dca, &b_had_dca);
+   ht_fChain->SetBranchAddress("had_angleXY", had_angleXY, &b_had_angleXY);
+   ht_fChain->SetBranchAddress("had_angleXYZ", had_angleXYZ, &b_had_angleXYZ);
+   ht_fChain->SetBranchAddress("had_dau1_chi2", had_dau1_chi2, &b_had_dau1_chi2);
+   ht_fChain->SetBranchAddress("had_dau1_nHits", had_dau1_nHits, &b_had_dau1_nHits);
+   ht_fChain->SetBranchAddress("had_dau1_pt", had_dau1_pt, &b_had_dau1_pt);
+   ht_fChain->SetBranchAddress("had_dau1_ipsigXY", had_dau1_ipsigXY, &b_had_dau1_ipsigXY);
+   ht_fChain->SetBranchAddress("had_dau1_ipsigZ", had_dau1_ipsigZ, &b_had_dau1_ipsigZ);
+   ht_fChain->SetBranchAddress("had_dau2_chi2", had_dau2_chi2, &b_had_dau2_chi2);
+   ht_fChain->SetBranchAddress("had_dau2_nHits", had_dau2_nHits, &b_had_dau2_nHits);
+   ht_fChain->SetBranchAddress("had_dau2_pt", had_dau2_pt, &b_had_dau2_pt);
+   ht_fChain->SetBranchAddress("had_dau2_ipsigXY", had_dau2_ipsigXY, &b_had_dau2_ipsigXY);
+   ht_fChain->SetBranchAddress("had_dau2_ipsigZ", had_dau2_ipsigZ, &b_had_dau2_ipsigZ);
+   ht_fChain->SetBranchAddress("had_nJet", had_nJet, &b_had_nJet);
+   ht_fChain->SetBranchAddress("had_nDau", had_nDau, &b_had_nDau);
+   ht_fChain->SetBranchAddress("had_dau1_charge", had_dau1_charge, &b_had_dau1_charge);
+   ht_fChain->SetBranchAddress("had_dau2_charge", had_dau2_charge, &b_had_dau2_charge);
+   ht_fChain->SetBranchAddress("had_idx", had_idx, &b_had_idx);
+   ht_fChain->SetBranchAddress("had_dau1_idx", had_dau1_idx, &b_had_dau1_idx);
+   ht_fChain->SetBranchAddress("had_dau2_idx", had_dau2_idx, &b_had_dau2_idx);
+   ht_fChain->SetBranchAddress("ngenHadron", &ngenHadron, &b_ngenHadron);
+   ht_fChain->SetBranchAddress("genHadron_dau1_pt", genHadron_dau1_pt, &b_genHadron_dau1_pt);
+   ht_fChain->SetBranchAddress("genHadron_dau2_pt", genHadron_dau2_pt, &b_genHadron_dau2_pt);
+   ht_fChain->SetBranchAddress("genHadron_dau1_eta", genHadron_dau1_eta, &b_genHadron_dau1_eta);
+   ht_fChain->SetBranchAddress("genHadron_dau2_eta", genHadron_dau2_eta, &b_genHadron_dau2_eta);
+   ht_fChain->SetBranchAddress("genHadron_dau1_phi", genHadron_dau1_phi, &b_genHadron_dau1_phi);
+   ht_fChain->SetBranchAddress("genHadron_dau2_phi", genHadron_dau2_phi, &b_genHadron_dau2_phi);
+   ht_fChain->SetBranchAddress("genHadron_vx", genHadron_vx, &b_genHadron_vx);
+   ht_fChain->SetBranchAddress("genHadron_vy", genHadron_vy, &b_genHadron_vy);
+   ht_fChain->SetBranchAddress("genHadron_vz", genHadron_vz, &b_genHadron_vz);
+   ht_fChain->SetBranchAddress("genHadron_isGenHadFromTsb", genHadron_isGenHadFromTsb, &b_genHadron_isGenHadFromTsb);
+   ht_fChain->SetBranchAddress("genHadron_dau1_pdgId", genHadron_dau1_pdgId, &b_genHadron_dau1_pdgId);
+   ht_fChain->SetBranchAddress("genHadron_dau2_pdgId", genHadron_dau2_pdgId, &b_genHadron_dau2_pdgId);
+   ht_fChain->SetBranchAddress("genHadron_isGenParticle", genHadron_isGenParticle, &b_genHadron_isGenParticle);
+   ht_fChain->SetBranchAddress("genHadron_isGenHadFromTop", genHadron_isGenHadFromTop, &b_genHadron_isGenHadFromTop);
+   ht_fChain->SetBranchAddress("genHadron_inVol", genHadron_inVol, &b_genHadron_inVol);
+   ht_fChain->SetBranchAddress("genHadron_isMatching", genHadron_isMatching, &b_genHadron_isMatching);
+   ht_fChain->SetBranchAddress("genHadron_isMatched", genHadron_isMatched, &b_genHadron_isMatched);
+*/
+   ht_fChain->SetBranchAddress("nhadTruth", &nhadTruth, &b_nhadTruth);
+   ht_fChain->SetBranchAddress("hadTruth_nMatched", hadTruth_nMatched, &b_hadTruth_nMatched);
+   ht_fChain->SetBranchAddress("hadTruth_nTrueDau", hadTruth_nTrueDau, &b_hadTruth_nTrueDau);
+   ht_fChain->SetBranchAddress("hadTruth_isHadFromTsb", hadTruth_isHadFromTsb, &b_hadTruth_isHadFromTsb);
+   ht_fChain->SetBranchAddress("hadTruth_isHadFromTop", hadTruth_isHadFromTop, &b_hadTruth_isHadFromTop);
+   ht_fChain->SetBranchAddress("hadTruth_isHadFromW", hadTruth_isHadFromW, &b_hadTruth_isHadFromW);
+   ht_fChain->SetBranchAddress("hadTruth_isHadFromS", hadTruth_isHadFromS, &b_hadTruth_isHadFromS);
+   ht_fChain->SetBranchAddress("hadTruth_isHadFromC", hadTruth_isHadFromC, &b_hadTruth_isHadFromC);
+   ht_fChain->SetBranchAddress("hadTruth_isHadFromB", hadTruth_isHadFromB, &b_hadTruth_isHadFromB);
+/*
+   ht_fChain->SetBranchAddress("nOtherPV", &nOtherPV, &b_nOtherPV);
+   ht_fChain->SetBranchAddress("OtherPV_z", OtherPV_z, &b_OtherPV_z);
+   ht_fChain->SetBranchAddress("PV_ndof", &PV_ndof, &b_PV_ndof);
+   ht_fChain->SetBranchAddress("PV_x", &PV_x, &b_PV_x);
+   ht_fChain->SetBranchAddress("PV_y", &PV_y, &b_PV_y);
+   ht_fChain->SetBranchAddress("PV_z", &PV_z, &b_PV_z);
+   ht_fChain->SetBranchAddress("PV_chi2", &PV_chi2, &b_PV_chi2);
+   ht_fChain->SetBranchAddress("PV_score", &PV_score, &b_PV_score);
+   ht_fChain->SetBranchAddress("PV_npvs", &PV_npvs, &b_PV_npvs);
+   ht_fChain->SetBranchAddress("PV_npvsGood", &PV_npvsGood, &b_PV_npvsGood);
+   ht_fChain->SetBranchAddress("nSV", &nSV, &b_nSV);
+   ht_fChain->SetBranchAddress("SV_dlen", SV_dlen, &b_SV_dlen);
+   ht_fChain->SetBranchAddress("SV_dlenSig", SV_dlenSig, &b_SV_dlenSig);
+   ht_fChain->SetBranchAddress("SV_pAngle", SV_pAngle, &b_SV_pAngle);
+   ht_fChain->SetBranchAddress("had_chi2", had_chi2, &b_had_chi2);
+   ht_fChain->SetBranchAddress("had_eta", had_eta, &b_had_eta);
+   ht_fChain->SetBranchAddress("had_mass", had_mass, &b_had_mass);
+   ht_fChain->SetBranchAddress("had_phi", had_phi, &b_had_phi);
+   ht_fChain->SetBranchAddress("had_pt", had_pt, &b_had_pt);
+   ht_fChain->SetBranchAddress("had_x", had_x, &b_had_x);
+   ht_fChain->SetBranchAddress("had_y", had_y, &b_had_y);
+   ht_fChain->SetBranchAddress("had_z", had_z, &b_had_z);
+   ht_fChain->SetBranchAddress("had_ndof", had_ndof, &b_had_ndof);
+   ht_fChain->SetBranchAddress("had_pdgId", had_pdgId, &b_had_pdgId);
+   ht_fChain->SetBranchAddress("genHadron_eta", genHadron_eta, &b_genHadron_eta);
+   ht_fChain->SetBranchAddress("genHadron_mass", genHadron_mass, &b_genHadron_mass);
+   ht_fChain->SetBranchAddress("genHadron_phi", genHadron_phi, &b_genHadron_phi);
+   ht_fChain->SetBranchAddress("genHadron_pt", genHadron_pt, &b_genHadron_pt);
+   ht_fChain->SetBranchAddress("genHadron_x", genHadron_x, &b_genHadron_x);
+   ht_fChain->SetBranchAddress("genHadron_y", genHadron_y, &b_genHadron_y);
+   ht_fChain->SetBranchAddress("genHadron_z", genHadron_z, &b_genHadron_z);
+   ht_fChain->SetBranchAddress("genHadron_pdgId", genHadron_pdgId, &b_genHadron_pdgId);
+   ht_fChain->SetBranchAddress("L1simulation_step", &L1simulation_step, &b_L1simulation_step);
+*/
    Notify();
 }
 
@@ -1698,8 +1719,8 @@ void HadTruthEvents::Show(Long64_t entry)
 {
 // Print contents of entry.
 // If entry is not specified, print current entry
-   if (!fChain) return;
-   fChain->Show(entry);
+   if (!ht_fChain) return;
+   ht_fChain->Show(entry);
 }
 Int_t HadTruthEvents::Cut(Long64_t entry)
 {

--- a/analysis/interface/dilepTopAnalysis.h
+++ b/analysis/interface/dilepTopAnalysis.h
@@ -50,7 +50,8 @@ public:
 
   virtual int EventSelection();
 
-  dilepTopAnalysis(TTree *tree=0, Bool_t isMC = false, Bool_t dl = false, Bool_t sle = false, Bool_t slm = false);
+  dilepTopAnalysis(TTree *tree = 0, Bool_t isMC = false, Bool_t dl = false, Bool_t sle = false, Bool_t slm = false);
+  dilepTopAnalysis(TTree *nano = 0, Bool_t isMC = false, TTree *had = 0, TTree *hadTruth = 0, Bool_t dl = true, Bool_t sle = false, Bool_t slm = false);
   ~dilepTopAnalysis();  
   virtual void Loop() = 0;
 

--- a/analysis/interface/hadAnalysis.h
+++ b/analysis/interface/hadAnalysis.h
@@ -45,7 +45,8 @@ public:
   //Function
   Double_t GetD(float pt, float eta, float phi, float m, float vx, float vy, float vz);
 
-  hadAnalysis(TTree *tree=0, Bool_t isMC = false, Bool_t dl = false, Bool_t sle = false, Bool_t slm = false);
+  hadAnalysis(TTree *tree = 0, Bool_t isMC = false, Bool_t dl = false, Bool_t sle = false, Bool_t slm = false);
+  hadAnalysis(TTree *nano = 0, Bool_t isMC = false, TTree *had = 0, TTree *hadTruth = 0, Bool_t dl = false, Bool_t sle = true, Bool_t slm = false);
   ~hadAnalysis();
   virtual void     Loop();
 };

--- a/analysis/interface/massAnalysis.h
+++ b/analysis/interface/massAnalysis.h
@@ -37,7 +37,7 @@ public :
   void setOutput(std::string outputName);
   void collectTMVAvalues();
   void cmesonSelection();
-  massAnalysis(TTree *tree=0, Bool_t isMC = false, Bool_t dl = false, Bool_t sle = false, Bool_t slm = false);
+  massAnalysis(TTree *tree = 0, Bool_t isMC = false, Bool_t dl = false, Bool_t sle = false, Bool_t slm = false);
   ~massAnalysis();
   virtual void     Loop();
 

--- a/analysis/interface/semiLepTopAnalysis.h
+++ b/analysis/interface/semiLepTopAnalysis.h
@@ -46,7 +46,9 @@ public:
 
   void Reset();
 
-  semiLepTopAnalysis(TTree *tree=0, Bool_t isMC = false, Bool_t sle = false, Bool_t slm = false);
+  semiLepTopAnalysis(TTree *tree = 0, Bool_t isMC = false, Bool_t sle = false, Bool_t slm = false);
+  semiLepTopAnalysis(TTree *nano = 0, Bool_t isMC = false, TTree *had = 0, TTree *hadTruth = 0, Bool_t isDilep = true, Bool_t isSemiLep = false);
+
   ~semiLepTopAnalysis();  
   virtual void Loop() = 0;
 };

--- a/analysis/interface/topAnalysis.h
+++ b/analysis/interface/topAnalysis.h
@@ -3,9 +3,11 @@
 
 #include "nanoAnalysis.h"
 #include "nano/external/interface/TopTriggerSF.h"
+#include "HadEvents.h"
+#include "HadTruthEvents.h"
 //#include "nano/external/interface/TTbarModeDefs.h"
 
-class topAnalysis : public nanoAnalysis
+class topAnalysis : public nanoAnalysis, public HadEvents, public HadTruthEvents
 {
 protected:
   std::vector<Float_t> b_csvweights;
@@ -22,7 +24,8 @@ public:
   std::vector<TParticle> jetSelection();
   std::vector<TParticle> bjetSelection();
 
-  topAnalysis(TTree *tree=0, Bool_t isMC = false, Bool_t isDilep = true, Bool_t isSemiLep = false);
+  topAnalysis(TTree *tree = 0, Bool_t isMC = false, Bool_t isDilep = true, Bool_t isSemiLep = false);
+  topAnalysis(TTree *nano = 0, Bool_t isMC = false, TTree *had = 0, TTree *hadTruth = 0, Bool_t isDilep = true, Bool_t isSemiLep = false);
   ~topAnalysis() {}
 };
 

--- a/analysis/interface/vtsAnalysis.h
+++ b/analysis/interface/vtsAnalysis.h
@@ -10,25 +10,22 @@ private:
   std::vector<int> qMC_;
   std::vector<int> genJet_;           
   std::vector<struct JetStat> recoJet_;
+  TTree *hadt = 0;
 
   //functions
   void ResetBranch();
+  void MakeBranch(TTree* t);
   void MatchingForMC();
   void HadronAnalysis();
-  void MakeBranch(TTree* t);
+  void hadronAnalysisWithHadTruth();
 
 public:
   void setOutput(std::string outputName);
 
-  vtsAnalysis(TTree *tree=0, Bool_t isMC = false, Bool_t dl = false, Bool_t sle = false, Bool_t slm = false);
-  ~vtsAnalysis();
-  virtual void     Loop();
+  vtsAnalysis(TTree *tree = 0, Bool_t isMC = false, Bool_t dl = false, Bool_t sle = false, Bool_t slm = false) : hadAnalysis(tree, isMC, dl, sle, slm) {}
+  vtsAnalysis(TTree *nano = 0, Bool_t isMC = false, TTree *had = 0, TTree *hadTruth = 0, Bool_t dl = false, Bool_t sle = false, Bool_t slm = false) : hadAnalysis(nano, isMC, had, hadTruth, dl, sle, slm) {}
+  ~vtsAnalysis() {}
+  virtual void Loop();
 };
-
-vtsAnalysis::vtsAnalysis(TTree *tree, Bool_t isMC, Bool_t dl, Bool_t sle, Bool_t slm) : hadAnalysis(tree, isMC, dl, sle, slm)
-{ }
-
-vtsAnalysis::~vtsAnalysis()
-{ }
 
 #endif

--- a/analysis/src/HadEvents.cc
+++ b/analysis/src/HadEvents.cc
@@ -1,11 +1,11 @@
-#define HadTruthEvents_cxx
-#include "nano/analysis/interface/HadTruthEvents.h"
+#define HadEvents_cxx
+#include "nano/analysis/interface/HadEvents.h"
 #include <TH2.h>
 #include <TStyle.h>
 #include <TCanvas.h>
 
-//void HadTruthEvents::Loop()
-//{
+//void HadTruthEvents::Loop() {}
+/*{
 //   In a ROOT session, you can do:
 //      root> .L HadTruthEvents.C
 //      root> HadTruthEvents t
@@ -29,17 +29,16 @@
 // METHOD2: replace line
 //    fChain->GetEntry(jentry);       //read all branches
 //by  b_branchname->GetEntry(ientry); //read only this branch
-/*
-   if (fChain == 0) return;
+   if (ht_fChain == 0) return;
 
-   Long64_t nentries = fChain->GetEntriesFast();
+   Long64_t nentries = ht_fChain->GetEntriesFast();
 
    Long64_t nbytes = 0, nb = 0;
    for (Long64_t jentry=0; jentry<nentries;jentry++) {
       Long64_t ientry = LoadTree(jentry);
       if (ientry < 0) break;
-      nb = fChain->GetEntry(jentry);   nbytes += nb;
+      nb = ht_fChain->GetEntry(jentry);   nbytes += nb;
       // if (Cut(ientry) < 0) continue;
    }
+}
 */
-//}

--- a/analysis/src/dilepTopAnalysis.cc
+++ b/analysis/src/dilepTopAnalysis.cc
@@ -7,6 +7,11 @@ dilepTopAnalysis::dilepTopAnalysis(TTree *tree, Bool_t isMC, Bool_t dl, Bool_t s
   m_isDL(dl), m_isSL_e(sle), m_isSL_m(slm) {
 }
 
+dilepTopAnalysis::dilepTopAnalysis(TTree *nano, Bool_t isMC, TTree *had, TTree *hadTruth, Bool_t dl, Bool_t sle, Bool_t slm) :
+  topAnalysis(nano, isMC, had, hadTruth, true, false),
+  m_isDL(dl), m_isSL_e(sle), m_isSL_m(slm) {
+}
+
 dilepTopAnalysis::~dilepTopAnalysis() {
 }
 

--- a/analysis/src/hadAnalysis.cc
+++ b/analysis/src/hadAnalysis.cc
@@ -3,6 +3,9 @@
 hadAnalysis::hadAnalysis(TTree *tree, Bool_t isMC, Bool_t dl, Bool_t sle, Bool_t slm) : dilepTopAnalysis(tree, isMC, dl, sle, slm)
 { }
 
+hadAnalysis::hadAnalysis(TTree *nano, Bool_t isMC, TTree *had, TTree *hadTruth, Bool_t dl, Bool_t sle, Bool_t slm) : dilepTopAnalysis(nano, isMC, had, hadTruth, dl, sle, slm)
+{ }
+
 hadAnalysis::~hadAnalysis()
 { }
 

--- a/analysis/src/semiLepTopAnalysis.cc
+++ b/analysis/src/semiLepTopAnalysis.cc
@@ -8,6 +8,12 @@ semiLepTopAnalysis::semiLepTopAnalysis(TTree *tree, Bool_t isMC, Bool_t sle, Boo
   m_isSL_m(slm) {
 }
 
+semiLepTopAnalysis::semiLepTopAnalysis(TTree *nano, Bool_t isMC, TTree *had, TTree *hadTruth, Bool_t sle, Bool_t slm) :
+  topAnalysis(nano, isMC, had, hadTruth, false, true),
+  m_isSL_e(sle),
+  m_isSL_m(slm) {
+}
+
 semiLepTopAnalysis::~semiLepTopAnalysis() {
 }
 

--- a/analysis/src/topAnalysis.cc
+++ b/analysis/src/topAnalysis.cc
@@ -8,6 +8,14 @@ topAnalysis::topAnalysis(TTree *tree, Bool_t isMC, Bool_t _isDilep, Bool_t _isSe
   isSemiLep(_isSemiLep)
 {}
 
+topAnalysis::topAnalysis(TTree *nano, Bool_t isMC, TTree *had, TTree *hadTruth, Bool_t _isDilep, Bool_t _isSemiLep) :
+  nanoAnalysis(nano, isMC),
+  HadEvents(had),
+  HadTruthEvents(hadTruth),
+  isDilep(_isDilep),
+  isSemiLep(_isSemiLep)
+{}
+
 vector<TParticle> topAnalysis::elecSelection() {
   vector<TParticle> elecs; 
   for (UInt_t i = 0; i < nElectron; ++i){
@@ -112,6 +120,7 @@ vector<TParticle> topAnalysis::jetSelection() {
     if (hasOverLap) continue;
     auto jet = TParticle();
     jet.SetMomentum(mom);
+    jet.SetFirstMother(i);
     jets.push_back(jet);
     for (UInt_t iu = 0; iu < 19; iu++) {
      // Jet_SF_CSV[iu] *= m_btagSF.getSF(jet, Jet_btagCSVV2[i], Jet_hadronFlavour[i], iu);

--- a/analysis/test/vts/vtsRun.sh
+++ b/analysis/test/vts/vtsRun.sh
@@ -1,0 +1,25 @@
+#!/bin/bash 
+
+#Temporary (not completed)
+
+TT012J_BSBAR="/xrootd/store/user/iawatson/tt012j_bsbar_2l_FxFx"
+TT012J_BBARS="/xrootd/store/user/iawatson/tt012j_bbars_2l_FxFx"
+
+
+NANO=$TT012J_BBARS/NANOAOD
+HAD=$TT012J_BBARS/HADAOD
+HADTRUTH=$TT012J_BBARS/HADTRUTHAOD
+
+RESULTPATH="root://cms-xrdr.sdfarm.kr:1094///xrd/store/user"
+
+for f in $NANO/*.root; do
+    if [[ $f -nt $HAD/`basename $f` ]]; then
+        echo "There is no the corresponding file in HADAOD !" $f
+    else
+        echo "Processing " $f
+        $SRT_CMSSW_BASE_SCRAMRTDEL/bin/slc6_amd64_gcc630/vtsAnalysis $f result/NANOHAD_`basename $f` $HAD/`basename $f`
+#$RESULTPATH/${USER}/tt012j_bsbar_2l_FxFx/NANOHAD_`basename $f` $HAD/`basename $f`
+    fi
+done
+
+


### PR DESCRIPTION
…ruthEvents)
Because objects are separated in the tt012j (or tt01j) samples (NANOAOD have GenPart_* and reco objects, HADAOD have had_* and HADTRUTH have hadTruth_*) I have split Events_2016v4 into three (each is Events_2016v4.h, HadEvents.h and HadTruthEvents.h)
vtsAnalysis code seems to work well but ,overall, codes which was modified is messy? so need to be modified more
The code for running vtsAnalysis is in .../analysis/test/vts/vtsRun.sh