### PR TITLE
Generalization of topObjectSelection.cc

### DIFF
--- a/analysis/interface/topEventSelectionDL.h
+++ b/analysis/interface/topEventSelectionDL.h
@@ -47,6 +47,8 @@ protected:
 public:
 
   enum TTLLChannel { CH_NOLL = 0, CH_MUEL, CH_ELEL, CH_MUMU };
+  
+  virtual int SetCutValues();
 
   virtual int EventSelection();
 

--- a/analysis/interface/topEventSelectionSL.h
+++ b/analysis/interface/topEventSelectionSL.h
@@ -41,6 +41,8 @@ protected:
 public:
 
   enum TTSLChannel { CH_NOLL = 0, CH_EL, CH_MU };
+  
+  int SetCutValues();
 
   int EventSelection();
 

--- a/analysis/interface/topEventSelectionSL.h
+++ b/analysis/interface/topEventSelectionSL.h
@@ -42,9 +42,9 @@ public:
 
   enum TTSLChannel { CH_NOLL = 0, CH_EL, CH_MU };
   
-  int SetCutValues();
+  virtual int SetCutValues();
 
-  int EventSelection();
+  virtual int EventSelection();
 
   void Reset();
 

--- a/analysis/interface/topObjectSelection.h
+++ b/analysis/interface/topObjectSelection.h
@@ -58,17 +58,6 @@ public:
   Float_t  cut_BJetConeSizeOverlap;
   Float_t *cut_BJetTypeBTag; // For example, set it as cut_BJetTypeBTag = Jet_btagCSVV2;
   Float_t  cut_BJetBTagCut;
-  
-  // In uncertainty study we need to switch the kinematic variables of jets
-  // The following variables are for this switch
-  // In the topObjectSelection.cc these variables are used instead of Jet_pt, Jet_mass, and so on.
-  // In default, these are same as the original ones, but when a user wants to study systematic uncertainty 
-  // so that he/she needs to switch them to the evaluated ones, 
-  // just touching them in anlalyser class will be okay, and this is for it.
-  Float_t *m_JetMass;
-  Float_t *m_JetPt;
-  Float_t *m_JetEta; // Actually the uncertainty evaluations didn't touch eta and phi. But... who knows?
-  Float_t *m_JetPhi;
 
 public: 
   // Tip: If you want to use your own additional cut with the existing cut, 
@@ -86,6 +75,21 @@ public:
   virtual bool additionalConditionForGenJet(UInt_t nIdx) {return true;};
   virtual bool additionalConditionForJet(UInt_t nIdx) {return true;};
   virtual bool additionalConditionForBJet(UInt_t nIdx) {return true;};
+  
+  // In uncertainty study we need to switch the kinematic variables of jets
+  // The following variables are for this switch
+  // In the topObjectSelection.cc these variables are used instead of Jet_pt, Jet_mass, and so on.
+  // In default, these are same as the original ones, but when a user wants to study systematic uncertainty 
+  // so that he/she needs to switch them to the evaluated ones, 
+  // just touching them in anlalyser class will be okay, and this is for it.
+  virtual void GetJetMassPt(UInt_t nIdx, 
+    Float_t &fJetMass, Float_t &fJetPt, Float_t &fJetEta, Float_t &fJetPhi) 
+  {
+    fJetMass  = Jet_mass[ nIdx ];
+    fJetPt = Jet_pt[ nIdx ];
+    fJetEta = Jet_eta[ nIdx ];
+    fJetPhi = Jet_phi[ nIdx ];
+  }
   
 public:
   std::vector<TParticle> muonSelection();

--- a/analysis/interface/topObjectSelection.h
+++ b/analysis/interface/topObjectSelection.h
@@ -10,8 +10,73 @@ class topObjectSelection : public nanoBase
 protected:
   std::vector<Float_t> b_csvweights;
   float b_btagweight;
+  Float_t b_isolep;
 
   bool isDilep, isSemiLep;
+  
+  Float_t b_maxBDiscr_nonb;
+  
+public:
+  // YOU MUST SET UP ALL IN THE BELOW!!!
+  // (SetCutValues() will force you to do it)
+  Float_t cut_ElectronPt;
+  Float_t cut_ElectronEta;
+  Int_t  *cut_ElectronIDType; // For example, cut_ElectronIDType = Electron_cutBased;
+  Int_t   cut_ElectronIDCut;
+  Float_t cut_ElectronSCEtaLower;
+  Float_t cut_ElectronSCEtaUpper;
+  Float_t cut_ElectronRelIso03All;
+  
+  Bool_t *cut_MuonIDType; // For example, cut_MuonIDType = Muon_tightId;
+  Float_t cut_MuonPt;
+  Float_t cut_MuonEta;
+  Float_t cut_MuonRelIso04All;
+  
+  Float_t cut_VetoElectronPt;
+  Float_t cut_VetoElectronEta;
+  Int_t  *cut_VetoElectronIDType; // For example, cut_VetoElectronIDType = Electron_cutBased;
+  Int_t   cut_VetoElectronIDCut;
+  Float_t cut_VetoElectronSCEtaLower;
+  Float_t cut_VetoElectronSCEtaUpper;
+  Float_t cut_VetoElectronRelIso03All;
+  
+  Bool_t *cut_VetoMuonIDType; // For example, cut_MuonIDType = NULL; or cut_MuonIDType = Muon_looseId;
+  Float_t cut_VetoMuonPt;
+  Float_t cut_VetoMuonEta;
+  Float_t cut_VetoMuonRelIso04All;
+  
+  Float_t cut_GenJetPt;
+  Float_t cut_GenJetEta;
+  Float_t cut_GenJetConeSizeOverlap;
+  
+  Int_t   cut_JetID;
+  Float_t cut_JetPt;
+  Float_t cut_JetEta;
+  Float_t cut_JetConeSizeOverlap;
+  
+  Int_t    cut_BJetID;
+  Float_t  cut_BJetPt;
+  Float_t  cut_BJetEta;
+  Float_t  cut_BJetConeSizeOverlap;
+  Float_t *cut_BJetTypeBTag; // For example, set it as cut_BJetTypeBTag = Jet_btagCSVV2;
+  Float_t  cut_BJetBTagCut;
+
+public: 
+  // Tip: If you want to use your own additional cut with the existing cut, 
+  // instead of copying the existing code, use the following: 
+  // bool [YOUR CLASS NAME]::additionalConditionFor[...]() {
+  //   if ( !topObjectSelection::additionalConditionFor[...]() ) return false;
+  //   [YOUR OWN CONDITIONS...]
+  // }
+  virtual bool additionalConditionForElectron(UInt_t nIdx) {return true;};
+  virtual bool additionalConditionForMuon(UInt_t nIdx) {return Muon_isPFcand[ nIdx ] && Muon_globalMu[ nIdx ];};
+  virtual bool additionalConditionForVetoElectron(UInt_t nIdx) {return true;};
+  virtual bool additionalConditionForVetoMuon(UInt_t nIdx) {
+    return Muon_isPFcand[ nIdx ] && ( Muon_globalMu[ nIdx ] || Muon_trackerMu[ nIdx ] );
+  };
+  virtual bool additionalConditionForGenJet(UInt_t nIdx) {return true;};
+  virtual bool additionalConditionForJet(UInt_t nIdx) {return true;};
+  virtual bool additionalConditionForBJet(UInt_t nIdx) {return true;};
   
 public:
   std::vector<TParticle> muonSelection();
@@ -27,6 +92,12 @@ public:
   topObjectSelection(TTree *tree=0, TTree *had=0, TTree *hadTruth=0, Bool_t isMC = false, Bool_t isDilep = true, Bool_t isSemiLep = false);
   topObjectSelection(TTree *tree=0, Bool_t isMC=false, Bool_t isDilep=true, Bool_t isSemiLep=false) : topObjectSelection(tree, 0, 0, isMC, isDilep, isSemiLep) {}
   ~topObjectSelection() {}
+  
+  // In this function you need to set all the cut conditions in the above
+  // If you do not set this function up (so that you didn't set the cuts), the compiler will deny your code, 
+  // so you can be noticed that you forgot the setting up.
+  // And you don't need to run this function indivisually; it will be run in the creator of this class.
+  virtual int SetCutValues() = 0;
 };
 
 #endif

--- a/analysis/interface/topObjectSelection.h
+++ b/analysis/interface/topObjectSelection.h
@@ -11,8 +11,6 @@ protected:
   std::vector<Float_t> b_csvweights;
   float b_btagweight;
   Float_t b_isolep;
-
-  bool isDilep, isSemiLep;
   
   Float_t b_maxBDiscr_nonb;
   
@@ -89,8 +87,8 @@ public:
 
   std::vector<TParticle> genJetSelection();
 
-  topObjectSelection(TTree *tree=0, TTree *had=0, TTree *hadTruth=0, Bool_t isMC = false, Bool_t isDilep = true, Bool_t isSemiLep = false);
-  topObjectSelection(TTree *tree=0, Bool_t isMC=false, Bool_t isDilep=true, Bool_t isSemiLep=false) : topObjectSelection(tree, 0, 0, isMC, isDilep, isSemiLep) {}
+  topObjectSelection(TTree *tree=0, TTree *had=0, TTree *hadTruth=0, Bool_t isMC = false);
+  topObjectSelection(TTree *tree=0, Bool_t isMC=false) : topObjectSelection(tree, 0, 0, isMC) {}
   ~topObjectSelection() {}
   
   // In this function you need to set all the cut conditions in the above

--- a/analysis/interface/topObjectSelection.h
+++ b/analysis/interface/topObjectSelection.h
@@ -58,6 +58,17 @@ public:
   Float_t  cut_BJetConeSizeOverlap;
   Float_t *cut_BJetTypeBTag; // For example, set it as cut_BJetTypeBTag = Jet_btagCSVV2;
   Float_t  cut_BJetBTagCut;
+  
+  // In uncertainty study we need to switch the kinematic variables of jets
+  // The following variables are for this switch
+  // In the topObjectSelection.cc these variables are used instead of Jet_pt, Jet_mass, and so on.
+  // In default, these are same as the original ones, but when a user wants to study systematic uncertainty 
+  // so that he/she needs to switch them to the evaluated ones, 
+  // just touching them in anlalyser class will be okay, and this is for it.
+  Float_t *m_JetMass;
+  Float_t *m_JetPt;
+  Float_t *m_JetEta; // Actually the uncertainty evaluations didn't touch eta and phi. But... who knows?
+  Float_t *m_JetPhi;
 
 public: 
   // Tip: If you want to use your own additional cut with the existing cut, 
@@ -75,21 +86,6 @@ public:
   virtual bool additionalConditionForGenJet(UInt_t nIdx) {return true;};
   virtual bool additionalConditionForJet(UInt_t nIdx) {return true;};
   virtual bool additionalConditionForBJet(UInt_t nIdx) {return true;};
-  
-  // In uncertainty study we need to switch the kinematic variables of jets
-  // The following variables are for this switch
-  // In the topObjectSelection.cc these variables are used instead of Jet_pt, Jet_mass, and so on.
-  // In default, these are same as the original ones, but when a user wants to study systematic uncertainty 
-  // so that he/she needs to switch them to the evaluated ones, 
-  // just touching them in anlalyser class will be okay, and this is for it.
-  virtual void GetJetMassPt(UInt_t nIdx, 
-    Float_t &fJetMass, Float_t &fJetPt, Float_t &fJetEta, Float_t &fJetPhi) 
-  {
-    fJetMass  = Jet_mass[ nIdx ];
-    fJetPt = Jet_pt[ nIdx ];
-    fJetEta = Jet_eta[ nIdx ];
-    fJetPhi = Jet_phi[ nIdx ];
-  }
   
 public:
   std::vector<TParticle> muonSelection();

--- a/analysis/interface/topObjectSelection.h
+++ b/analysis/interface/topObjectSelection.h
@@ -58,17 +58,6 @@ public:
   Float_t  cut_BJetConeSizeOverlap;
   Float_t *cut_BJetTypeBTag; // For example, set it as cut_BJetTypeBTag = Jet_btagCSVV2;
   Float_t  cut_BJetBTagCut;
-  
-  // In uncertainty study we need to switch the kinematic variables of jets
-  // The following variables are for this switch
-  // In the topObjectSelection.cc these variables are used instead of Jet_pt, Jet_mass, and so on.
-  // In default, these are same as the original ones, but when a user wants to study systematic uncertainty 
-  // so that he/she needs to switch them to the evaluated ones, 
-  // just touching them in anlalyser class will be okay, and this is for it.
-  Float_t *m_JetMass;
-  Float_t *m_JetPt;
-  Float_t *m_JetEta; // Actually the uncertainty evaluations didn't touch eta and phi. But... who knows?
-  Float_t *m_JetPhi;
 
 public: 
   // Tip: If you want to use your own additional cut with the existing cut, 

--- a/analysis/interface/topObjectSelection.h
+++ b/analysis/interface/topObjectSelection.h
@@ -58,6 +58,17 @@ public:
   Float_t  cut_BJetConeSizeOverlap;
   Float_t *cut_BJetTypeBTag; // For example, set it as cut_BJetTypeBTag = Jet_btagCSVV2;
   Float_t  cut_BJetBTagCut;
+  
+  // In uncertainty study we need to switch the kinematic variables of jets
+  // The following variables are for this switch
+  // In the topObjectSelection.cc these variables are used instead of Jet_pt, Jet_mass, and so on.
+  // In default, these are same as the original ones, but when a user wants to study systematic uncertainty 
+  // so that he/she needs to switch them to the evaluated ones, 
+  // just touching them in anlalyser class will be okay, and this is for it.
+  Float_t *m_JetMass;
+  Float_t *m_JetPt;
+  Float_t *m_JetEta; // Actually the uncertainty evaluations didn't touch eta and phi. But... who knows?
+  Float_t *m_JetPhi;
 
 public: 
   // Tip: If you want to use your own additional cut with the existing cut, 

--- a/analysis/src/topEventSelectionDL.cc
+++ b/analysis/src/topEventSelectionDL.cc
@@ -3,8 +3,10 @@
 using std::vector;
 
 topEventSelectionDL::topEventSelectionDL(TTree *tree, TTree *had, TTree *hadTruth, Bool_t isMC, Bool_t dl, Bool_t sle, Bool_t slm) :
-  topObjectSelection(tree, had, hadTruth, isMC, true, false),
-  m_isDL(dl), m_isSL_e(sle), m_isSL_m(slm) {
+  topObjectSelection(tree, had, hadTruth, isMC),
+  m_isDL(dl), m_isSL_e(sle), m_isSL_m(slm) 
+{
+  SetCutValues();
 }
 
 topEventSelectionDL::~topEventSelectionDL() {

--- a/analysis/src/topEventSelectionDL.cc
+++ b/analysis/src/topEventSelectionDL.cc
@@ -10,6 +10,52 @@ topEventSelectionDL::topEventSelectionDL(TTree *tree, TTree *had, TTree *hadTrut
 topEventSelectionDL::~topEventSelectionDL() {
 }
 
+int topEventSelectionDL::SetCutValues() {
+  cut_ElectronPt = 20;
+  cut_ElectronEta = 2.4;
+  cut_ElectronIDType = Electron_cutBased;
+  cut_ElectronIDCut = 3;
+  cut_ElectronSCEtaLower = 1.4442;
+  cut_ElectronSCEtaUpper = 1.566;
+  cut_ElectronRelIso03All = 10000000000;
+  
+  cut_MuonIDType = Muon_tightId;
+  cut_MuonPt = 20;
+  cut_MuonEta = 2.4;
+  cut_MuonRelIso04All = 0.15;
+  
+  cut_VetoElectronPt = 20;
+  cut_VetoElectronEta = 2.4;
+  cut_VetoElectronIDType = Electron_cutBased;
+  cut_VetoElectronIDCut = 3;
+  cut_VetoElectronSCEtaLower = 1.4442;
+  cut_VetoElectronSCEtaUpper = 1.566;
+  cut_VetoElectronRelIso03All = 10000000000;
+  
+  cut_VetoMuonIDType = NULL;
+  cut_VetoMuonPt = 10;
+  cut_VetoMuonEta = 2.4;
+  cut_VetoMuonRelIso04All = 0.25;
+  
+  cut_GenJetPt = 30;
+  cut_GenJetEta = 2.4;
+  cut_GenJetConeSizeOverlap = 0.4;
+  
+  cut_JetID = 1;
+  cut_JetPt = 30;
+  cut_JetEta = 2.4;
+  cut_JetConeSizeOverlap = 0.4;
+  
+  cut_BJetID = 1;
+  cut_BJetPt = 30;
+  cut_BJetEta = 2.4;
+  cut_BJetConeSizeOverlap = 0.4;
+  cut_BJetTypeBTag = Jet_btagCSVV2;
+  cut_BJetBTagCut = 0.8484;
+  
+  return 0;
+}
+
 int topEventSelectionDL::EventSelection() {
   h_cutFlow->Fill(0);
 

--- a/analysis/src/topEventSelectionSL.cc
+++ b/analysis/src/topEventSelectionSL.cc
@@ -3,7 +3,7 @@
 using std::vector;
 
 topEventSelectionSL::topEventSelectionSL(TTree *tree, TTree *had, TTree *hadTruth, Bool_t isMC, Bool_t sle, Bool_t slm) :
-  topObjectSelection(tree, had, hadTruth, isMC, false, true),
+  topObjectSelection(tree, had, hadTruth, isMC),
   h_nevents(0),
   h_genweights(0),
   h_cutFlow(0),

--- a/analysis/src/topEventSelectionSL.cc
+++ b/analysis/src/topEventSelectionSL.cc
@@ -18,6 +18,52 @@ topEventSelectionSL::~topEventSelectionSL()
 {
 }
 
+int topEventSelectionSL::SetCutValues() {
+  cut_ElectronPt = 30;
+  cut_ElectronEta = 2.4;
+  cut_ElectronIDType = Electron_cutBased;
+  cut_ElectronIDCut = 3;
+  cut_ElectronSCEtaLower = 1.4442;
+  cut_ElectronSCEtaUpper = 1.566;
+  cut_ElectronRelIso03All = 10000000000;
+  
+  cut_MuonIDType = Muon_tightId;
+  cut_MuonPt = 26;
+  cut_MuonEta = 2.1;
+  cut_MuonRelIso04All = 0.15;
+  
+  cut_VetoElectronPt = 20;
+  cut_VetoElectronEta = 2.4;
+  cut_VetoElectronIDType = Electron_cutBased;
+  cut_VetoElectronIDCut = 3;
+  cut_VetoElectronSCEtaLower = 1.4442;
+  cut_VetoElectronSCEtaUpper = 1.566;
+  cut_VetoElectronRelIso03All = 10000000000;
+  
+  cut_VetoMuonIDType = NULL;
+  cut_VetoMuonPt = 10;
+  cut_VetoMuonEta = 2.4;
+  cut_VetoMuonRelIso04All = 0.25;
+  
+  cut_GenJetPt = 30;
+  cut_GenJetEta = 2.4;
+  cut_GenJetConeSizeOverlap = 0.4;
+  
+  cut_JetID = 1;
+  cut_JetPt = 30;
+  cut_JetEta = 2.4;
+  cut_JetConeSizeOverlap = 0.4;
+  
+  cut_BJetID = 1;
+  cut_BJetPt = 30;
+  cut_BJetEta = 2.4;
+  cut_BJetConeSizeOverlap = 0.4;
+  cut_BJetTypeBTag = Jet_btagCSVV2;
+  cut_BJetBTagCut = 0.8484;
+  
+  return 0;
+}
+
 void topEventSelectionSL::Reset()
 {
   b_step = 0;

--- a/analysis/src/topEventSelectionSL.cc
+++ b/analysis/src/topEventSelectionSL.cc
@@ -12,6 +12,7 @@ topEventSelectionSL::topEventSelectionSL(TTree *tree, TTree *had, TTree *hadTrut
   m_isSL_e(sle),
   m_isSL_m(slm)
 {
+  SetCutValues();
 }
 
 topEventSelectionSL::~topEventSelectionSL()

--- a/analysis/src/topObjectSelection.cc
+++ b/analysis/src/topObjectSelection.cc
@@ -2,10 +2,8 @@
 
 using std::vector;
 
-topObjectSelection::topObjectSelection(TTree *tree, TTree *had, TTree *hadTruth, Bool_t isMC, Bool_t _isDilep, Bool_t _isSemiLep) :
-  nanoBase(tree, had, hadTruth, isMC),
-  isDilep(_isDilep),
-  isSemiLep(_isSemiLep)
+topObjectSelection::topObjectSelection(TTree *tree, TTree *had, TTree *hadTruth, Bool_t isMC) :
+  nanoBase(tree, had, hadTruth, isMC)
 {}
 
 vector<TParticle> topObjectSelection::elecSelection() {

--- a/analysis/src/topObjectSelection.cc
+++ b/analysis/src/topObjectSelection.cc
@@ -4,7 +4,12 @@ using std::vector;
 
 topObjectSelection::topObjectSelection(TTree *tree, TTree *had, TTree *hadTruth, Bool_t isMC) :
   nanoBase(tree, had, hadTruth, isMC)
-{}
+{
+  m_JetMass = Jet_mass;
+  m_JetPt = Jet_pt;
+  m_JetEta = Jet_eta;
+  m_JetPhi = Jet_phi;
+}
 
 vector<TParticle> topObjectSelection::elecSelection() {
   vector<TParticle> elecs; 
@@ -122,11 +127,11 @@ vector<TParticle> topObjectSelection::jetSelection() {
   vector<TParticle> jets;
   //float Jet_SF_CSV[19] = {1.0,};
   for (UInt_t i = 0; i < nJet; ++i){
-    if (Jet_pt[i] < cut_JetPt) continue;
-    if (std::abs(Jet_eta[i]) > cut_JetEta) continue;
+    if (m_JetPt[i] < cut_JetPt) continue;
+    if (std::abs(m_JetEta[i]) > cut_JetEta) continue;
     if (Jet_jetId[i] < cut_JetID) continue;
     TLorentzVector mom;
-    mom.SetPtEtaPhiM(Jet_pt[i], Jet_eta[i], Jet_phi[i], Jet_mass[i]);
+    mom.SetPtEtaPhiM(m_JetPt[i], m_JetEta[i], m_JetPhi[i], m_JetMass[i]);
     bool hasOverLap = false;
     for (auto lep : recoleps){
         if (mom.TLorentzVector::DeltaR(lep) < cut_JetConeSizeOverlap) hasOverLap = true;
@@ -141,7 +146,7 @@ vector<TParticle> topObjectSelection::jetSelection() {
     BTagEntry::JetFlavor JF = BTagEntry::FLAV_UDSG;
     if (abs(Jet_hadronFlavour[i]) == 5) JF = BTagEntry::FLAV_B;
     //else if (abs(Jet_hadronFlavour[i]) == 4) JF = BTagEntry::FLAV_C;
-    auto bjetSF = m_btagSF.eval_auto_bounds("central", JF , Jet_eta[i], Jet_pt[i], Jet_btagCSVV2[i]);
+    auto bjetSF = m_btagSF.eval_auto_bounds("central", JF , m_JetEta[i], m_JetPt[i], Jet_btagCSVV2[i]);
     b_btagweight *= bjetSF;
     for (UInt_t iu = 0; iu < 19; iu++) {
      // Jet_SF_CSV[iu] *= m_btagSF.getSF(jet, Jet_btagCSVV2[i], Jet_hadronFlavour[i], iu);
@@ -156,12 +161,12 @@ vector<TParticle> topObjectSelection::jetSelection() {
 vector<TParticle> topObjectSelection::bjetSelection() {
   vector<TParticle> bjets;
   for (UInt_t i = 0; i < nJet; ++i ) {
-    if (Jet_pt[i] < cut_BJetPt) continue;
-    if (std::abs(Jet_eta[i]) > cut_BJetEta) continue;
+    if (m_JetPt[i] < cut_BJetPt) continue;
+    if (std::abs(m_JetEta[i]) > cut_BJetEta) continue;
     if (Jet_jetId[i] < cut_BJetID) continue;
     if (cut_BJetTypeBTag[i] < cut_BJetBTagCut) continue;
     TLorentzVector mom;
-    mom.SetPtEtaPhiM(Jet_pt[i], Jet_eta[i], Jet_phi[i], Jet_mass[i]);
+    mom.SetPtEtaPhiM(m_JetPt[i], m_JetEta[i], m_JetPhi[i], m_JetMass[i]);
     bool hasOverLap = false;
     for (auto lep : recoleps) {
       if (mom.TLorentzVector::DeltaR(lep) < cut_BJetConeSizeOverlap) hasOverLap = true;

--- a/analysis/src/topObjectSelection.cc
+++ b/analysis/src/topObjectSelection.cc
@@ -4,12 +4,7 @@ using std::vector;
 
 topObjectSelection::topObjectSelection(TTree *tree, TTree *had, TTree *hadTruth, Bool_t isMC) :
   nanoBase(tree, had, hadTruth, isMC)
-{
-  m_JetMass = Jet_mass;
-  m_JetPt = Jet_pt;
-  m_JetEta = Jet_eta;
-  m_JetPhi = Jet_phi;
-}
+{}
 
 vector<TParticle> topObjectSelection::elecSelection() {
   vector<TParticle> elecs; 
@@ -127,11 +122,11 @@ vector<TParticle> topObjectSelection::jetSelection() {
   vector<TParticle> jets;
   //float Jet_SF_CSV[19] = {1.0,};
   for (UInt_t i = 0; i < nJet; ++i){
-    if (m_JetPt[i] < cut_JetPt) continue;
-    if (std::abs(m_JetEta[i]) > cut_JetEta) continue;
+    if (Jet_pt[i] < cut_JetPt) continue;
+    if (std::abs(Jet_eta[i]) > cut_JetEta) continue;
     if (Jet_jetId[i] < cut_JetID) continue;
     TLorentzVector mom;
-    mom.SetPtEtaPhiM(m_JetPt[i], m_JetEta[i], m_JetPhi[i], m_JetMass[i]);
+    mom.SetPtEtaPhiM(Jet_pt[i], Jet_eta[i], Jet_phi[i], Jet_mass[i]);
     bool hasOverLap = false;
     for (auto lep : recoleps){
         if (mom.TLorentzVector::DeltaR(lep) < cut_JetConeSizeOverlap) hasOverLap = true;
@@ -146,7 +141,7 @@ vector<TParticle> topObjectSelection::jetSelection() {
     BTagEntry::JetFlavor JF = BTagEntry::FLAV_UDSG;
     if (abs(Jet_hadronFlavour[i]) == 5) JF = BTagEntry::FLAV_B;
     //else if (abs(Jet_hadronFlavour[i]) == 4) JF = BTagEntry::FLAV_C;
-    auto bjetSF = m_btagSF.eval_auto_bounds("central", JF , m_JetEta[i], m_JetPt[i], Jet_btagCSVV2[i]);
+    auto bjetSF = m_btagSF.eval_auto_bounds("central", JF , Jet_eta[i], Jet_pt[i], Jet_btagCSVV2[i]);
     b_btagweight *= bjetSF;
     for (UInt_t iu = 0; iu < 19; iu++) {
      // Jet_SF_CSV[iu] *= m_btagSF.getSF(jet, Jet_btagCSVV2[i], Jet_hadronFlavour[i], iu);
@@ -161,12 +156,12 @@ vector<TParticle> topObjectSelection::jetSelection() {
 vector<TParticle> topObjectSelection::bjetSelection() {
   vector<TParticle> bjets;
   for (UInt_t i = 0; i < nJet; ++i ) {
-    if (m_JetPt[i] < cut_BJetPt) continue;
-    if (std::abs(m_JetEta[i]) > cut_BJetEta) continue;
+    if (Jet_pt[i] < cut_BJetPt) continue;
+    if (std::abs(Jet_eta[i]) > cut_BJetEta) continue;
     if (Jet_jetId[i] < cut_BJetID) continue;
     if (cut_BJetTypeBTag[i] < cut_BJetBTagCut) continue;
     TLorentzVector mom;
-    mom.SetPtEtaPhiM(m_JetPt[i], m_JetEta[i], m_JetPhi[i], m_JetMass[i]);
+    mom.SetPtEtaPhiM(Jet_pt[i], Jet_eta[i], Jet_phi[i], Jet_mass[i]);
     bool hasOverLap = false;
     for (auto lep : recoleps) {
       if (mom.TLorentzVector::DeltaR(lep) < cut_BJetConeSizeOverlap) hasOverLap = true;

--- a/analysis/src/topObjectSelection.cc
+++ b/analysis/src/topObjectSelection.cc
@@ -4,12 +4,7 @@ using std::vector;
 
 topObjectSelection::topObjectSelection(TTree *tree, TTree *had, TTree *hadTruth, Bool_t isMC) :
   nanoBase(tree, had, hadTruth, isMC)
-{
-  m_JetMass = Jet_mass;
-  m_JetPt = Jet_pt;
-  m_JetEta = Jet_eta;
-  m_JetPhi = Jet_phi;
-}
+{}
 
 vector<TParticle> topObjectSelection::elecSelection() {
   vector<TParticle> elecs; 
@@ -127,11 +122,14 @@ vector<TParticle> topObjectSelection::jetSelection() {
   vector<TParticle> jets;
   //float Jet_SF_CSV[19] = {1.0,};
   for (UInt_t i = 0; i < nJet; ++i){
-    if (m_JetPt[i] < cut_JetPt) continue;
-    if (std::abs(m_JetEta[i]) > cut_JetEta) continue;
+    Float_t fJetMass, fJetPt, fJetEta, fJetPhi;
+    GetJetMassPt(i, fJetMass, fJetPt, fJetEta, fJetPhi);
+    
+    if (fJetPt < cut_JetPt) continue;
+    if (std::abs(fJetEta) > cut_JetEta) continue;
     if (Jet_jetId[i] < cut_JetID) continue;
     TLorentzVector mom;
-    mom.SetPtEtaPhiM(m_JetPt[i], m_JetEta[i], m_JetPhi[i], m_JetMass[i]);
+    mom.SetPtEtaPhiM(fJetPt, fJetEta, fJetPhi, fJetMass);
     bool hasOverLap = false;
     for (auto lep : recoleps){
         if (mom.TLorentzVector::DeltaR(lep) < cut_JetConeSizeOverlap) hasOverLap = true;
@@ -146,7 +144,7 @@ vector<TParticle> topObjectSelection::jetSelection() {
     BTagEntry::JetFlavor JF = BTagEntry::FLAV_UDSG;
     if (abs(Jet_hadronFlavour[i]) == 5) JF = BTagEntry::FLAV_B;
     //else if (abs(Jet_hadronFlavour[i]) == 4) JF = BTagEntry::FLAV_C;
-    auto bjetSF = m_btagSF.eval_auto_bounds("central", JF , m_JetEta[i], m_JetPt[i], Jet_btagCSVV2[i]);
+    auto bjetSF = m_btagSF.eval_auto_bounds("central", JF , fJetEta, fJetPt, Jet_btagCSVV2[i]);
     b_btagweight *= bjetSF;
     for (UInt_t iu = 0; iu < 19; iu++) {
      // Jet_SF_CSV[iu] *= m_btagSF.getSF(jet, Jet_btagCSVV2[i], Jet_hadronFlavour[i], iu);
@@ -161,12 +159,15 @@ vector<TParticle> topObjectSelection::jetSelection() {
 vector<TParticle> topObjectSelection::bjetSelection() {
   vector<TParticle> bjets;
   for (UInt_t i = 0; i < nJet; ++i ) {
-    if (m_JetPt[i] < cut_BJetPt) continue;
-    if (std::abs(m_JetEta[i]) > cut_BJetEta) continue;
+    Float_t fJetMass, fJetPt, fJetEta, fJetPhi;
+    GetJetMassPt(i, fJetMass, fJetPt, fJetEta, fJetPhi);
+    
+    if (fJetPt < cut_BJetPt) continue;
+    if (std::abs(fJetEta) > cut_BJetEta) continue;
     if (Jet_jetId[i] < cut_BJetID) continue;
     if (cut_BJetTypeBTag[i] < cut_BJetBTagCut) continue;
     TLorentzVector mom;
-    mom.SetPtEtaPhiM(m_JetPt[i], m_JetEta[i], m_JetPhi[i], m_JetMass[i]);
+    mom.SetPtEtaPhiM(fJetPt, fJetEta, fJetPhi, fJetMass);
     bool hasOverLap = false;
     for (auto lep : recoleps) {
       if (mom.TLorentzVector::DeltaR(lep) < cut_BJetConeSizeOverlap) hasOverLap = true;

--- a/analysis/src/topObjectSelection.cc
+++ b/analysis/src/topObjectSelection.cc
@@ -11,12 +11,13 @@ topObjectSelection::topObjectSelection(TTree *tree, TTree *had, TTree *hadTruth,
 vector<TParticle> topObjectSelection::elecSelection() {
   vector<TParticle> elecs; 
   for (UInt_t i = 0; i < nElectron; ++i){
-    if (Electron_pt[i] < 20) continue;
-    if (isSemiLep) { if (Electron_pt[i] < 30) continue; }
-    if (std::abs(Electron_eta[i]) > 2.4) continue;
-    if (Electron_cutBased[i] < 3) continue; 
+    if (Electron_pt[i] < cut_ElectronPt) continue;
+    if (std::abs(Electron_eta[i]) > cut_ElectronEta) continue;
+    if (cut_ElectronIDType != NULL && cut_ElectronIDType[i] < cut_ElectronIDCut) continue; 
     float el_scEta = Electron_deltaEtaSC[i] + Electron_eta[i];
-    if ( std::abs(el_scEta) > 1.4442 &&  std::abs(el_scEta) < 1.566 ) continue;
+    if ( cut_ElectronSCEtaLower < std::abs(el_scEta) && std::abs(el_scEta) < cut_ElectronSCEtaUpper ) continue;
+    if ( !additionalConditionForElectron(i) ) continue;
+    
     TLorentzVector mom;
     mom.SetPtEtaPhiM(Electron_pt[i], Electron_eta[i], Electron_phi[i], Electron_mass[i]);
 
@@ -33,14 +34,12 @@ vector<TParticle> topObjectSelection::elecSelection() {
 vector<TParticle> topObjectSelection::muonSelection() {
   vector<TParticle> muons; 
   for (UInt_t i = 0; i < nMuon; ++i){
-    if (!Muon_tightId[i]) continue;
-    if (Muon_pt[i] < 20) continue;
-    if (isSemiLep) { if (Muon_pt[i] < 26) continue; }
-    if (std::abs(Muon_eta[i]) > 2.4) continue;
-    if (isSemiLep) { if (std::abs(Muon_eta[i]) > 2.1) continue; }
-    if (Muon_pfRelIso04_all[i] > 0.15) continue;
-    if (!Muon_globalMu[i]) continue;
-    if (!Muon_isPFcand[i]) continue;
+    if (cut_MuonIDType != NULL && !cut_MuonIDType[i]) continue;
+    if (Muon_pt[i] < cut_MuonPt) continue;
+    if (std::abs(Muon_eta[i]) > cut_MuonEta) continue;
+    if (Muon_pfRelIso04_all[i] > cut_MuonRelIso04All) continue;
+    if ( !additionalConditionForMuon(i) ) continue;
+    
     TLorentzVector mom;
     mom.SetPtEtaPhiM(Muon_pt[i], Muon_eta[i], Muon_phi[i], Muon_mass[i]);
     auto muon = TParticle();
@@ -56,11 +55,14 @@ vector<TParticle> topObjectSelection::muonSelection() {
 vector<TParticle> topObjectSelection::vetoElecSelection() {
   vector<TParticle> elecs; 
   for (UInt_t i = 0; i < nElectron; ++i){
-    if (Electron_pt[i] < 20) continue;
-    if (std::abs(Electron_eta[i]) > 2.4) continue;
-    if (Electron_cutBased[i] < 3) continue; 
+    if (Electron_pt[i] < cut_VetoElectronPt) continue;
+    if (std::abs(Electron_eta[i]) > cut_VetoElectronEta) continue;
+    if (cut_VetoElectronIDType != NULL && cut_VetoElectronIDType[i] < cut_VetoElectronIDCut) continue; 
     float el_scEta = Electron_deltaEtaSC[i] + Electron_eta[i];
-    if ( std::abs(el_scEta) > 1.4442 &&  std::abs(el_scEta) < 1.566 ) continue;
+    if ( cut_VetoElectronSCEtaLower < std::abs(el_scEta) && 
+                                      std::abs(el_scEta) < cut_VetoElectronSCEtaUpper ) continue;
+    if ( !additionalConditionForVetoElectron(i) ) continue;
+    
     TLorentzVector mom;
     mom.SetPtEtaPhiM(Electron_pt[i], Electron_eta[i], Electron_phi[i], Electron_mass[i]);
     auto elec = TParticle();
@@ -79,13 +81,12 @@ vector<TParticle> topObjectSelection::vetoMuonSelection() {
     // if (!Muon_looseId[i]) continue;
 
     // https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonIdRun2#Loose_Muon
-    if (!Muon_isPFcand[i]) continue;
-    if (!(Muon_globalMu[i] || Muon_trackerMu[i])) continue;
-
+    if (cut_VetoMuonIDType != NULL && !cut_VetoMuonIDType[i]) continue;
+    if (Muon_pt[i] < cut_VetoMuonPt) continue;
+    if (std::abs(Muon_eta[i]) > cut_VetoMuonEta) continue;
+    if (Muon_pfRelIso04_all[i] > cut_VetoMuonRelIso04All) continue;
+    if ( !additionalConditionForVetoMuon(i) ) continue;
     
-    if (Muon_pt[i] < 10) continue;
-    if (std::abs(Muon_eta[i]) > 2.4) continue;
-    if (Muon_pfRelIso04_all[i] > 0.25) continue;
     TLorentzVector mom;
     mom.SetPtEtaPhiM(Muon_pt[i], Muon_eta[i], Muon_phi[i], Muon_mass[i]);
     auto muon = TParticle();
@@ -100,15 +101,17 @@ vector<TParticle> topObjectSelection::vetoMuonSelection() {
 vector<TParticle> topObjectSelection::genJetSelection() {
   vector<TParticle> jets;
   for (UInt_t i = 0; i < nJet; ++i){
-    if (GenJet_pt[i] < 30) continue;
-    if (std::abs(GenJet_eta[i]) > 2.4) continue;
+    if (GenJet_pt[i] < cut_GenJetPt) continue;
+    if (std::abs(GenJet_eta[i]) > cut_GenJetEta) continue;
     TLorentzVector mom;
     mom.SetPtEtaPhiM(GenJet_pt[i], GenJet_eta[i], GenJet_phi[i], GenJet_mass[i]);
     bool hasOverLap = false;
     for (auto lep : recoleps){
-        if (mom.TLorentzVector::DeltaR(lep) < 0.4) hasOverLap = true;
+        if (mom.TLorentzVector::DeltaR(lep) < cut_GenJetConeSizeOverlap) hasOverLap = true;
     }
     if (hasOverLap) continue;
+    if ( !additionalConditionForGenJet(i) ) continue;
+    
     auto jet = TParticle();
     jet.SetMomentum(mom);
     jet.SetFirstMother(i);
@@ -119,28 +122,35 @@ vector<TParticle> topObjectSelection::genJetSelection() {
 
 vector<TParticle> topObjectSelection::jetSelection() {
   vector<TParticle> jets;
-  float Jet_SF_CSV[19] = {1.0,};
+  //float Jet_SF_CSV[19] = {1.0,};
   for (UInt_t i = 0; i < nJet; ++i){
-    if (Jet_pt[i] < 30) continue;
-    if (std::abs(Jet_eta[i]) > 2.4) continue;
-    if (Jet_jetId[i] < 1) continue;
+    if (Jet_pt[i] < cut_JetPt) continue;
+    if (std::abs(Jet_eta[i]) > cut_JetEta) continue;
+    if (Jet_jetId[i] < cut_JetID) continue;
     TLorentzVector mom;
     mom.SetPtEtaPhiM(Jet_pt[i], Jet_eta[i], Jet_phi[i], Jet_mass[i]);
     bool hasOverLap = false;
     for (auto lep : recoleps){
-        if (mom.TLorentzVector::DeltaR(lep) < 0.4) hasOverLap = true;
+        if (mom.TLorentzVector::DeltaR(lep) < cut_JetConeSizeOverlap) hasOverLap = true;
     }
     if (hasOverLap) continue;
+    if ( !additionalConditionForJet(i) ) continue;
+    
     auto jet = TParticle();
     jet.SetMomentum(mom);
     jet.SetFirstMother(i);
     jets.push_back(jet);
+    BTagEntry::JetFlavor JF = BTagEntry::FLAV_UDSG;
+    if (abs(Jet_hadronFlavour[i]) == 5) JF = BTagEntry::FLAV_B;
+    //else if (abs(Jet_hadronFlavour[i]) == 4) JF = BTagEntry::FLAV_C;
+    auto bjetSF = m_btagSF.eval_auto_bounds("central", JF , Jet_eta[i], Jet_pt[i], Jet_btagCSVV2[i]);
+    b_btagweight *= bjetSF;
     for (UInt_t iu = 0; iu < 19; iu++) {
      // Jet_SF_CSV[iu] *= m_btagSF.getSF(jet, Jet_btagCSVV2[i], Jet_hadronFlavour[i], iu);
     }
   }
-  for (UInt_t i =0; i<19; i++) b_csvweights.push_back(Jet_SF_CSV[i]);
-  b_btagweight = Jet_SF_CSV[0];
+  //for (UInt_t i =0; i<19; i++) b_csvweights.push_back(Jet_SF_CSV[i]);
+  //b_btagweight = Jet_SF_CSV[0];
   
   return jets;
 }
@@ -148,17 +158,19 @@ vector<TParticle> topObjectSelection::jetSelection() {
 vector<TParticle> topObjectSelection::bjetSelection() {
   vector<TParticle> bjets;
   for (UInt_t i = 0; i < nJet; ++i ) {
-    if (Jet_pt[i] < 30) continue;
-    if (std::abs(Jet_eta[i]) > 2.4) continue;
-    if (Jet_jetId[i] < 1) continue;
-    if (Jet_btagCSVV2[i] < 0.8484) continue;
+    if (Jet_pt[i] < cut_BJetPt) continue;
+    if (std::abs(Jet_eta[i]) > cut_BJetEta) continue;
+    if (Jet_jetId[i] < cut_BJetID) continue;
+    if (cut_BJetTypeBTag[i] < cut_BJetBTagCut) continue;
     TLorentzVector mom;
     mom.SetPtEtaPhiM(Jet_pt[i], Jet_eta[i], Jet_phi[i], Jet_mass[i]);
     bool hasOverLap = false;
     for (auto lep : recoleps) {
-      if (mom.TLorentzVector::DeltaR(lep) < 0.4) hasOverLap = true;
+      if (mom.TLorentzVector::DeltaR(lep) < cut_BJetConeSizeOverlap) hasOverLap = true;
     }
     if (hasOverLap) continue;
+    if ( !additionalConditionForBJet(i) ) continue;
+    
     auto bjet = TParticle();
     bjet.SetMomentum(mom);
     bjet.SetFirstMother(i);

--- a/analysis/src/topObjectSelection.cc
+++ b/analysis/src/topObjectSelection.cc
@@ -4,7 +4,12 @@ using std::vector;
 
 topObjectSelection::topObjectSelection(TTree *tree, TTree *had, TTree *hadTruth, Bool_t isMC) :
   nanoBase(tree, had, hadTruth, isMC)
-{}
+{
+  m_JetMass = Jet_mass;
+  m_JetPt = Jet_pt;
+  m_JetEta = Jet_eta;
+  m_JetPhi = Jet_phi;
+}
 
 vector<TParticle> topObjectSelection::elecSelection() {
   vector<TParticle> elecs; 
@@ -122,14 +127,11 @@ vector<TParticle> topObjectSelection::jetSelection() {
   vector<TParticle> jets;
   //float Jet_SF_CSV[19] = {1.0,};
   for (UInt_t i = 0; i < nJet; ++i){
-    Float_t fJetMass, fJetPt, fJetEta, fJetPhi;
-    GetJetMassPt(i, fJetMass, fJetPt, fJetEta, fJetPhi);
-    
-    if (fJetPt < cut_JetPt) continue;
-    if (std::abs(fJetEta) > cut_JetEta) continue;
+    if (m_JetPt[i] < cut_JetPt) continue;
+    if (std::abs(m_JetEta[i]) > cut_JetEta) continue;
     if (Jet_jetId[i] < cut_JetID) continue;
     TLorentzVector mom;
-    mom.SetPtEtaPhiM(fJetPt, fJetEta, fJetPhi, fJetMass);
+    mom.SetPtEtaPhiM(m_JetPt[i], m_JetEta[i], m_JetPhi[i], m_JetMass[i]);
     bool hasOverLap = false;
     for (auto lep : recoleps){
         if (mom.TLorentzVector::DeltaR(lep) < cut_JetConeSizeOverlap) hasOverLap = true;
@@ -144,7 +146,7 @@ vector<TParticle> topObjectSelection::jetSelection() {
     BTagEntry::JetFlavor JF = BTagEntry::FLAV_UDSG;
     if (abs(Jet_hadronFlavour[i]) == 5) JF = BTagEntry::FLAV_B;
     //else if (abs(Jet_hadronFlavour[i]) == 4) JF = BTagEntry::FLAV_C;
-    auto bjetSF = m_btagSF.eval_auto_bounds("central", JF , fJetEta, fJetPt, Jet_btagCSVV2[i]);
+    auto bjetSF = m_btagSF.eval_auto_bounds("central", JF , m_JetEta[i], m_JetPt[i], Jet_btagCSVV2[i]);
     b_btagweight *= bjetSF;
     for (UInt_t iu = 0; iu < 19; iu++) {
      // Jet_SF_CSV[iu] *= m_btagSF.getSF(jet, Jet_btagCSVV2[i], Jet_hadronFlavour[i], iu);
@@ -159,15 +161,12 @@ vector<TParticle> topObjectSelection::jetSelection() {
 vector<TParticle> topObjectSelection::bjetSelection() {
   vector<TParticle> bjets;
   for (UInt_t i = 0; i < nJet; ++i ) {
-    Float_t fJetMass, fJetPt, fJetEta, fJetPhi;
-    GetJetMassPt(i, fJetMass, fJetPt, fJetEta, fJetPhi);
-    
-    if (fJetPt < cut_BJetPt) continue;
-    if (std::abs(fJetEta) > cut_BJetEta) continue;
+    if (m_JetPt[i] < cut_BJetPt) continue;
+    if (std::abs(m_JetEta[i]) > cut_BJetEta) continue;
     if (Jet_jetId[i] < cut_BJetID) continue;
     if (cut_BJetTypeBTag[i] < cut_BJetBTagCut) continue;
     TLorentzVector mom;
-    mom.SetPtEtaPhiM(fJetPt, fJetEta, fJetPhi, fJetMass);
+    mom.SetPtEtaPhiM(m_JetPt[i], m_JetEta[i], m_JetPhi[i], m_JetMass[i]);
     bool hasOverLap = false;
     for (auto lep : recoleps) {
       if (mom.TLorentzVector::DeltaR(lep) < cut_BJetConeSizeOverlap) hasOverLap = true;


### PR DESCRIPTION
Using this, users of topObjectSelection.cc and topEventSelection[DS]L.cc can manage their own object selection cut more conveniently

Just adding the following code is okay

int [USER'S CLASS]::SetCutValues() {
  topEventSelection[DS]L::SetCutValue(); // It's optional, but in many case you will need it
  
  //// Put your conditions for your analysis
  // For example, if you want a cut muon.Pt() > 30, put the following: 
  // cut_MuonPt = 30;
  // The list for cut values are listed up in interface/topObjectSelection.h
  // or you can follow SetCutValues() of topEventSelection[DS]L, which is declared in topEventSelection[DS]L.cc
  
  return 0;
}

If needed, you can change additionalConditionFor[...](UInit_t nIdx) for your own additional cut condtions.