### PR TITLE
Bug on lepton SF

### DIFF
--- a/analysis/interface/topEventSelectionSL.h
+++ b/analysis/interface/topEventSelectionSL.h
@@ -47,6 +47,9 @@ public:
   virtual int EventSelection();
 
   void Reset();
+  
+  virtual Bool_t TrigForEl() {return HLT_Ele27_WPTight_Gsf;}
+  virtual Bool_t TrigForMu() {return HLT_IsoTkMu24 || HLT_IsoMu24;}
 
   topEventSelectionSL(TTree *tree=0, TTree *had=0, TTree *hadTruth=0, Bool_t isMC = false, Bool_t sle = false, Bool_t slm = false);
   topEventSelectionSL(TTree *tree=0, Bool_t isMC=false, Bool_t sle=false, Bool_t slm=false) : topEventSelectionSL(tree, 0, 0, isMC, sle, slm) {}

--- a/analysis/src/topEventSelectionSL.cc
+++ b/analysis/src/topEventSelectionSL.cc
@@ -117,6 +117,7 @@ int topEventSelectionSL::EventSelection()
   //Triggers
   b_trig_m = HLT_IsoTkMu24 || HLT_IsoMu24;
   b_trig_e = HLT_Ele27_WPTight_Gsf;
+  if ( !( b_trig_m || b_trig_e ) ) return b_step;
 
   // TODO Check trigger requirements (TTbarXSecSynchronization page doesn't have yet)
   
@@ -128,30 +129,10 @@ int topEventSelectionSL::EventSelection()
   //   if (!b_trig_e) return b_step;
   // }
 
-  //leptonS
-  b_mueffweight    = muonSF_.getScaleFactor(recolep, 13, 0);
-  b_mueffweight_up = muonSF_.getScaleFactor(recolep, 13, 1);
-  b_mueffweight_dn = muonSF_.getScaleFactor(recolep, 13, -1);
-
-  b_eleffweight    = elecSF_.getScaleFactor(recolep, 11, 0);
-  b_eleffweight_up = elecSF_.getScaleFactor(recolep, 11, 1);
-  b_eleffweight_dn = elecSF_.getScaleFactor(recolep, 11, -1);
-
-  b_tri = b_tri_up = b_tri_dn = 0;
-  b_tri = 1; //computeTrigSF(recolep1, recolep2);
-  b_tri_up = 1; //computeTrigSF(recolep1, recolep2, 1);
-  b_tri_dn = 1; //computeTrigSF(recolep1, recolep2, -1);
-
   b_met = MET_pt;
 
   auto muons = muonSelection();
   auto elecs = elecSelection();
-
-  auto bjets = bjetSelection();
-  b_nbjet = bjets.size();
-
-  auto jets = jetSelection();
-  b_njet = jets.size();
 
   if (muons.size() + elecs.size() != 1) return b_step;
   b_step = 1;
@@ -161,16 +142,29 @@ int topEventSelectionSL::EventSelection()
   if (h_cutFlowLep) h_cutFlowLep->Fill(1);
   
   if (muons.size() == 1) {
-      recolep = muons[0];
-      b_channel = CH_MU;
+    recolep = muons[0];
+    b_channel = CH_MU;
+    
+    b_mueffweight    = muonSF_.getScaleFactor(recolep, 13, 0);
+    b_mueffweight_up = muonSF_.getScaleFactor(recolep, 13, 1);
+    b_mueffweight_dn = muonSF_.getScaleFactor(recolep, 13, -1);
   } else if (elecs.size() == 1) {
-      recolep = elecs[0];
-      b_channel = CH_EL;
+    recolep = elecs[0];
+    b_channel = CH_EL;
+    
+    b_eleffweight    = elecSF_.getScaleFactor(recolep, 11, 0);
+    b_eleffweight_up = elecSF_.getScaleFactor(recolep, 11, 1);
+    b_eleffweight_dn = elecSF_.getScaleFactor(recolep, 11, -1);
   }
 
   recolep.Momentum(b_lep);
-
+  b_lep_pid = recolep.GetPdgCode();
   recoleps.push_back(b_lep);
+
+  b_tri = b_tri_up = b_tri_dn = 0;
+  b_tri = 1; //computeTrigSF(recolep1, recolep2);
+  b_tri_up = 1; //computeTrigSF(recolep1, recolep2, 1);
+  b_tri_dn = 1; //computeTrigSF(recolep1, recolep2, -1);
 
   // Veto Leptons
 
@@ -185,6 +179,12 @@ int topEventSelectionSL::EventSelection()
   b_step = 2;
   if (h_cutFlow) h_cutFlow->Fill(4);
   if (h_cutFlowLep) h_cutFlowLep->Fill(2);
+
+  auto bjets = bjetSelection();
+  b_nbjet = bjets.size();
+
+  auto jets = jetSelection();
+  b_njet = jets.size();
 
   if (b_njet > 0) {
     b_step = 3;

--- a/analysis/src/topEventSelectionSL.cc
+++ b/analysis/src/topEventSelectionSL.cc
@@ -115,8 +115,8 @@ int topEventSelectionSL::EventSelection()
   if (h_cutFlow) h_cutFlow->Fill(2);
 
   //Triggers
-  b_trig_m = HLT_IsoTkMu24 || HLT_IsoMu24;
-  b_trig_e = HLT_Ele27_WPTight_Gsf;
+  b_trig_m = TrigForMu();
+  b_trig_e = TrigForEl();
   if ( !( b_trig_m || b_trig_e ) ) return b_step;
 
   // TODO Check trigger requirements (TTbarXSecSynchronization page doesn't have yet)


### PR DESCRIPTION
I found a bug on evaluation of lepton scale factor; the evaluators must be below of setting `recolep`, but in the existing code they are above so that they used `recolep` in the previous event!

Also, I made some additional modifications for optimization
 - Trigger cut; if the event doesn't pass the given trigger conditions, we don't need to continue
 - Moved the jet & b-jet selections; if the event doesn't satisfy the conditions for leptons, why we run the selections for jets?

On the other hand, I modified the check of trigger to be more general so that one can override `TrigForEl()` and `TrigForMu()` to use his/her own trigger configuration.