### PR TITLE
Fix bug in vtsAnalyser

### DIFF
--- a/analysis/bin/vtsAnalyser.cc
+++ b/analysis/bin/vtsAnalyser.cc
@@ -73,6 +73,10 @@ int main(int argc, char* argv[])
           TFile *hadTruthFile = TFile::Open(hadTruthFileName, "READ");
           TTree *hadTree(0);      
           TTree *hadTruthTree(0);
+          if (string(inFileName).find("/djeon/tt012j_bbars_2l_FxFx/") != std::string::npos) { // Let had-like files be null since there are wrong files in ~/djeon/tt012j_bbars_2l_FxFx/~ for now
+              hadFile = NULL;
+              hadTruthFile = NULL;
+          }
           if (hadFile != NULL) hadTree = (TTree*) hadFile->Get("Events");
           if (hadTruthFile != NULL) hadTruthTree = (TTree*) hadTruthFile->Get("Events");
           else cout << ">>>>> There dosen't exist hadTruth info. -----> Use NANOTREE and HADTREE <<<<< " << endl;
@@ -354,6 +358,7 @@ void vtsAnalyser::MatchingForMC() {
 }
 
 void vtsAnalyser::FillTMVATrees() {
+  if (m_isMC && m_jetDeltaRs.size() == 0 ) return; // For the case of absence of 2 gen quarks from top quark (m_tqMC.size() < 2), pass FillTMVATrees()
   sort(m_jetDeltaRs.begin(), m_jetDeltaRs.end(), [] (jetInfo a, jetInfo b) { return (a.pt > b.pt); } ); // pT ordering
   auto highestPt = m_jetDeltaRs[0];  auto NhighestPt = m_jetDeltaRs[1];
   auto closestToTq1 = *min_element(m_jetDeltaRs.begin(), m_jetDeltaRs.end(), [] (jetInfo a, jetInfo b) { return (a.drsj < b.drsj); } ); // dR(tq1,jet) ordering
@@ -370,9 +375,10 @@ void vtsAnalyser::FillTMVATrees() {
     if (m_isMC) { IdentifyJet(ij, closestToTq1.idx, closestToTq2.idx); }
 
     b_isHighest = 0; b_isClosestToLep = 0;
-    if      (j == highestPt.idx     || j == NhighestPt.idx)    b_isHighest = 1;
-    else if (j == closestToLep1.idx || j == closestToLep2.idx) b_isClosestToLep = 1;
-    b_dr1   = closestToTq1.drsj;  b_dr2   = closestToTq2.drbj;
+    if (j == highestPt.idx     || j == NhighestPt.idx)    b_isHighest = 1;
+    if (j == closestToLep1.idx || j == closestToLep2.idx) b_isClosestToLep = 1;
+    b_dr1 = closestToTq1.drsj;
+    b_dr2 = closestToTq2.drbj;
 
     TLorentzVector jet_tlv;
     jet_tlv.SetPtEtaPhiM(Jet_pt[j], Jet_eta[j], Jet_phi[j], Jet_mass[j]);
@@ -515,7 +521,7 @@ void vtsAnalyser::SetMVAReader() {
   hadTMVABranch(Ks_chi2); hadTMVABranch(Ks_dca);
   hadTMVABranch(Ks_dau1_chi2); hadTMVABranch(Ks_dau1_ipsigXY); hadTMVABranch(Ks_dau1_ipsigZ); hadTMVABranch(Ks_dau1_pt);
   hadTMVABranch(Ks_dau2_chi2); hadTMVABranch(Ks_dau2_ipsigXY); hadTMVABranch(Ks_dau2_ipsigZ); hadTMVABranch(Ks_dau2_pt);
-  m_hadReader->BookMVA("KS_BDT", "/cms/ldap_home/tt8888tt/nanoAOD_tmp/src/nano/analysis/test/vts/tmva/pp_real_vs_fake/weights/vts_dR_04_Had_BDT.weights.xml");
+  m_hadReader->BookMVA("KS_BDT", "/cms/ldap_home/wjjang/wj_nanoAOD_CMSSW_9_4_4/src/nano/analysis/test/vts/tmva/dataset/Had/pp_real_vs_fake/weights/vts_dR_04_Had_BDT.weights.xml");
 
   m_jetReader = new TMVA::Reader();
   jetTMVABranch(pt);  jetTMVABranch(eta);  jetTMVABranch(phi);  jetTMVABranch(mass);

--- a/analysis/bin/vtsAnalyser.cc
+++ b/analysis/bin/vtsAnalyser.cc
@@ -468,8 +468,8 @@ void vtsAnalyser::SetJetValues(int i) {
   }
 
   /* Save tmva value */
-  //b_Jet_bdt_score = m_jetReader->EvaluateMVA("Jet_BDT_highest");
-  //b_JKS_bdt_score = m_jksReader->EvaluateMVA("JKS_BDT_highest");
+  b_Jet_bdt_score = m_jetReader->EvaluateMVA("Jet_BDT_highest");
+  b_JKS_bdt_score = m_jksReader->EvaluateMVA("JKS_BDT_highest");
 }
 
 void vtsAnalyser::SetHadronValues(int i) {
@@ -550,7 +550,7 @@ void vtsAnalyser::SetMVAReader() {
 
   jksTMVABranch(Ks_bdt_score);
   jksTMVABranch(Ks_x);
-  m_jksReader->BookMVA("JKs_BDT_highest", "/cms/ldap_home/wjjang/wj_nanoAOD_CMSSW_9_4_4/src/nano/analysis/test/vts/tmva/dataset/JKS/pp_combined_JKs_BDT_highest/weights/vts_dR_04_Jet_BDT.weights.xml");
+  m_jksReader->BookMVA("JKS_BDT_highest", "/cms/ldap_home/wjjang/wj_nanoAOD_CMSSW_9_4_4/src/nano/analysis/test/vts/tmva/dataset/JKS/pp_combined_JKS_BDT_highest/weights/vts_dR_04_Jet_BDT.weights.xml");
 }
 
 void vtsAnalyser::ResetJetTree() {

--- a/analysis/interface/Events_2016v4.h
+++ b/analysis/interface/Events_2016v4.h
@@ -2160,20 +2160,14 @@ Events::Events(TTree *tree, TTree *had, TTree *hadTruth) : fChain(0), h_fChain(0
 
 Events::~Events()
 {
-  if (!fChain) return;
-  delete fChain->GetCurrentFile();
-  if (!h_fChain) {
-    if (!ht_fChain) return;
-    else delete ht_fChain->GetCurrentFile();
-  } else h_fChain->GetCurrentFile();
-  if (!ht_fChain) return;
-  else delete ht_fChain->GetCurrentFile();
-/*
-   if (!fChain) return;
-   delete fChain->GetCurrentFile();
-   if (h_fChain) delete h_fChain->GetCurrentFile();
-   if (ht_fChain) delete ht_fChain->GetCurrentFile();
-*/
+  if (fChain == h_fChain) h_fChain = nullptr;
+  if (fChain == ht_fChain) ht_fChain = nullptr;
+  if (h_fChain == ht_fChain) ht_fChain = nullptr;
+
+  if (fChain) delete fChain->GetCurrentFile();
+  if (h_fChain) delete h_fChain->GetCurrentFile();
+  if (ht_fChain) delete ht_fChain->GetCurrentFile();
+
 }
 
 #include<iostream>

--- a/analysis/test/vts/tmva/vts_dR_04_Had.C
+++ b/analysis/test/vts/tmva/vts_dR_04_Had.C
@@ -113,16 +113,16 @@ int vts_dR_04_Had( TString myMethodList = "" )
   TFile *bbars_bsbar_pythia(0);       TFile *bbars_bsbar_herwig(0);
   TFile *bbars_bsbar_bbbar_pythia(0);
 
-  TString sample_bbars_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20181120/tt012j_bbars_2l_FxFx_sum_349.root";
-  TString sample_bbars_herwig             = "/xrootd/store/user/wjjang/test/sum_tt012j/20181120/tt012j_bbars_2l_FxFx_herwigpp_sum_49.root";
+  TString sample_bbars_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190304/tt012j_bbars_2l_FxFx_sum_349.root";
+  TString sample_bbars_herwig             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190304/tt012j_bbars_2l_FxFx_herwigpp_sum_49.root";
 
-  TString sample_bsbar_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20181120/tt012j_bsbar_2l_FxFx_sum_350.root";
-  TString sample_bsbar_herwig             = "/xrootd/store/user/wjjang/test/sum_tt012j/20181120/tt012j_bsbar_2l_FxFx_herwigpp_sum_49.root";
+  TString sample_bsbar_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190304/tt012j_bsbar_2l_FxFx_sum_350.root";
+  TString sample_bsbar_herwig             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190304/tt012j_bsbar_2l_FxFx_herwigpp_sum_49.root";
 
-  TString sample_bbars_bsbar_pythia       = "/xrootd/store/user/wjjang/test/sum_tt012j/20181120/tt012j_bbars_bsbar_sum_349_350.root";
-  TString sample_bbars_bsbar_herwig       = "/xrootd/store/user/wjjang/test/sum_tt012j/20181120/tt012j_bbars_bsbar_herwigpp_sum_49.root";
+  TString sample_bbars_bsbar_pythia       = "/xrootd/store/user/wjjang/test/sum_tt012j/20190304/tt012j_bbars_bsbar_sum_349_350.root";
+  TString sample_bbars_bsbar_herwig       = "/xrootd/store/user/wjjang/test/sum_tt012j/20190304/tt012j_bbars_bsbar_herwigpp_sum_49.root";
 
-  TString sample_bbars_bsbar_bbbar_pythia = "/xrootd/store/user/wjjang/test/sum_tt012j/20181120/tt012j_bbars_bsbar_bbbar_sum_349_350_201.root";
+  TString sample_bbars_bsbar_bbbar_pythia = "/xrootd/store/user/wjjang/test/sum_tt012j/20190304/tt012j_bbars_bsbar_bbbar_sum_349_350_201.root";//"/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bbars_bsbar_bbbar_sum_349_350_201.root";
 
   bbars_pythia = TFile::Open( sample_bbars_pythia );                          //bbars_herwig = TFile::Open( sample_bbars_herwig );
   bsbar_pythia = TFile::Open( sample_bsbar_pythia );                          //bsbar_herwig = TFile::Open( sample_bsbar_herwig );
@@ -165,8 +165,8 @@ int vts_dR_04_Had( TString myMethodList = "" )
 
   Double_t signalWeight     = 1.0; Double_t backgroundWeight = 1.0;
 
-  TCut cut_real = "nMatched == 2";
-  TCut cut_fake = "nMatched != 2";
+  TCut cut_real = "Ks_nMatched == 2";
+  TCut cut_fake = "Ks_nMatched != 2";
   // It's for 20181120 samples
   TString opt_pp = "nTrain_Signal=12000:nTrain_Background=870000:SplitMode=Random:NormMode=NumEvents:!V";
 

--- a/analysis/test/vts/tmva/vts_dR_04_Jet.C
+++ b/analysis/test/vts/tmva/vts_dR_04_Jet.C
@@ -37,30 +37,30 @@ void addJetVariable(TMVA::DataLoader *dataloader) {
 }
 
 void addHadVariablePP(TMVA::DataLoader *dataloader) {
-  dataloader->AddVariable("KS_d",                'F');
-  dataloader->AddVariable("KS_pt",               'F');
-  dataloader->AddVariable("KS_eta",              'F');
-  dataloader->AddVariable("KS_phi",              'F');
-  dataloader->AddVariable("KS_mass",             'F');
-  dataloader->AddVariable("KS_lxy",              'F');
-  dataloader->AddVariable("KS_lxySig",           'F');
-  dataloader->AddVariable("KS_l3D",              'F');
-  dataloader->AddVariable("KS_l3DSig",           'F');
-  dataloader->AddVariable("KS_legDR",            'F');
-  dataloader->AddVariable("KS_angleXY",          'F');
-  dataloader->AddVariable("KS_angleXYZ",         'F');
-  dataloader->AddVariable("KS_chi2",             'F');
-  dataloader->AddVariable("KS_dca",              'F');
-  dataloader->AddVariable("KS_dau1_chi2",        'F');
-  dataloader->AddVariable("KS_dau1_ipsigXY",     'F');
-  dataloader->AddVariable("KS_dau1_ipsigZ",      'F');
-  dataloader->AddVariable("KS_dau1_pt",          'F');
-  dataloader->AddVariable("KS_dau2_chi2",        'F');
-  dataloader->AddVariable("KS_dau2_ipsigXY",     'F');
-  dataloader->AddVariable("KS_dau2_ipsigZ",      'F');
-  dataloader->AddVariable("KS_dau2_pt",          'F');
-  dataloader->AddVariable("KS_best_bdt",         'F');
-  dataloader->AddVariable("KS_x", 'F');
+  dataloader->AddVariable("Ks_d",                'F');
+  dataloader->AddVariable("Ks_pt",               'F');
+  dataloader->AddVariable("Ks_eta",              'F');
+  dataloader->AddVariable("Ks_phi",              'F');
+  dataloader->AddVariable("Ks_mass",             'F');
+  dataloader->AddVariable("Ks_lxy",              'F');
+  dataloader->AddVariable("Ks_lxySig",           'F');
+  dataloader->AddVariable("Ks_l3D",              'F');
+  dataloader->AddVariable("Ks_l3DSig",           'F');
+  dataloader->AddVariable("Ks_legDR",            'F');
+  dataloader->AddVariable("Ks_angleXY",          'F');
+  dataloader->AddVariable("Ks_angleXYZ",         'F');
+  dataloader->AddVariable("Ks_chi2",             'F');
+  dataloader->AddVariable("Ks_dca",              'F');
+  dataloader->AddVariable("Ks_dau1_chi2",        'F');
+  dataloader->AddVariable("Ks_dau1_ipsigXY",     'F');
+  dataloader->AddVariable("Ks_dau1_ipsigZ",      'F');
+  dataloader->AddVariable("Ks_dau1_pt",          'F');
+  dataloader->AddVariable("Ks_dau2_chi2",        'F');
+  dataloader->AddVariable("Ks_dau2_ipsigXY",     'F');
+  dataloader->AddVariable("Ks_dau2_ipsigZ",      'F');
+  dataloader->AddVariable("Ks_dau2_pt",          'F');
+  dataloader->AddVariable("Ks_bdt_score",         'F');
+  dataloader->AddVariable("Ks_x", 'F');
 }
 
 void addTree(TMVA::DataLoader *dataloader, TTree* sig, TTree* bkg, Double_t sigW = 1.0, Double_t bkgW = 1.0) {
@@ -96,12 +96,15 @@ void setJKS(std::map<std::string,int> Use,
             float backgroundWeight = 1,
             TCut cut_sig = "isSJet",
             TCut cut_bkg = "!isSJet",
-            TString opt = "SplitMode=Random:NormMode=NumEvents:!V") {
+            TString opt = "SplitMode=Random:NormMode=NumEvents:!V",
+            float sig_ratio=0.7,
+            float bkg_ratio=0.7) {
+  TString opt_t = "nTrain_Signal="+std::to_string(int(sigTrain->Draw("",cut_sig,"")*sig_ratio))+":nTrain_Background="+std::to_string(int(bkgTrain->Draw("",cut_bkg,"")*bkg_ratio))+":"+opt;
   addJetVariable(dataloader);
   if (string(dataloader->GetName()).find("pp_") != std::string::npos) addHadVariablePP(dataloader);
   else addHadVariablePP(dataloader);
   addTree(dataloader, sigTrain, bkgTrain, signalWeight, backgroundWeight);
-  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt );
+  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt_t );
   addMethod(Use, factory, dataloader);
 }
 void setJKS(std::map<std::string,int> Use, 
@@ -115,12 +118,15 @@ void setJKS(std::map<std::string,int> Use,
             float backgroundWeight = 1, 
             TCut cut_sig = "isSJet", 
             TCut cut_bkg = "!isSJet", 
-            TString opt = "SplitMode=Random:NormMode=NumEvents:!V") {
+            TString opt = "SplitMode=Random:NormMode=NumEvents:!V",
+            float sig_ratio=0.7,
+            float bkg_ratio=0.7) {
+  TString opt_t = "nTrain_Signal="+std::to_string(int(sigTrain->Draw("",cut_sig,"")*sig_ratio))+":nTrain_Background="+std::to_string(int(bkgTrain->Draw("",cut_bkg,"")*bkg_ratio))+":"+opt;
   addJetVariable(dataloader);
   if (string(dataloader->GetName()).find("pp_") != std::string::npos) addHadVariablePP(dataloader);
   else addHadVariablePP(dataloader);
   addTree(dataloader, sigTrain, sigTest, bkgTrain, bkgTest, signalWeight, backgroundWeight);
-  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt );
+  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt_t );
   addMethod(Use, factory, dataloader);
 }
 
@@ -133,10 +139,14 @@ void setJ(std::map<std::string,int> Use,
             float backgroundWeight = 1, 
             TCut cut_sig = "isSJet", 
             TCut cut_bkg = "!isSJet", 
-            TString opt = "SplitMode=Random:NormMode=NumEvents:!V") {
+            TString opt = "SplitMode=Random:NormMode=NumEvents:!V",
+            float sig_ratio=0.7,
+            float bkg_ratio=0.7) {
+  TString opt_t = "nTrain_Signal="+std::to_string(int(sigTrain->Draw("",cut_sig,"")*sig_ratio))+":nTrain_Background="+std::to_string(int(bkgTrain->Draw("",cut_bkg,"")*bkg_ratio))+":"+opt;
+  std::cout << opt_t << std::endl;
   addJetVariable(dataloader);
   addTree(dataloader, sigTrain, bkgTrain, signalWeight, backgroundWeight);
-  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt );
+  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt_t );
   addMethod(Use, factory, dataloader);
 }
 void setJ(std::map<std::string,int> Use, 
@@ -150,10 +160,13 @@ void setJ(std::map<std::string,int> Use,
             float backgroundWeight = 1,
             TCut cut_sig = "isSJet",
             TCut cut_bkg = "!isSJet",
-            TString opt = "SplitMode=Random:NormMode=NumEvents:!V") {
+            TString opt = "SplitMode=Random:NormMode=NumEvents:!V",
+            float sig_ratio=0.7,
+            float bkg_ratio=0.7) {
+  TString opt_t = "nTrain_Signal="+std::to_string(int(sigTrain->Draw("",cut_sig,"")*sig_ratio))+":nTrain_Background="+std::to_string(int(bkgTrain->Draw("",cut_bkg,"")*bkg_ratio))+":"+opt;
   addJetVariable(dataloader);
   addTree(dataloader, sigTrain, sigTest, bkgTrain, bkgTest, signalWeight, backgroundWeight);
-  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt );
+  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt_t );
   addMethod(Use, factory, dataloader);
 }
 
@@ -166,10 +179,13 @@ void setHad(std::map<std::string,int> Use,
             float backgroundWeight = 1,
             TCut cut_sig = "isSJet",
             TCut cut_bkg = "!isSJet",
-            TString opt = "SplitMode=Random:NormMode=NumEvents:!V") {
+            TString opt = "SplitMode=Random:NormMode=NumEvents:!V",
+            float sig_ratio=0.7,
+            float bkg_ratio=0.7) {
+  TString opt_t = "nTrain_Signal="+std::to_string(int(sigTrain->Draw("",cut_sig,"")*sig_ratio))+":nTrain_Background="+std::to_string(int(bkgTrain->Draw("",cut_bkg,"")*bkg_ratio))+":"+opt;
   addHadVariablePP(dataloader);
   addTree(dataloader, sigTrain, bkgTrain, signalWeight, backgroundWeight);
-  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt );
+  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt_t );
   addMethod(Use, factory, dataloader);
 }
 void setHad(std::map<std::string,int> Use,
@@ -183,10 +199,13 @@ void setHad(std::map<std::string,int> Use,
             float backgroundWeight = 1,
             TCut cut_sig = "isSJet",
             TCut cut_bkg = "!isSJet",
-            TString opt = "SplitMode=Random:NormMode=NumEvents:!V") {
+            TString opt = "SplitMode=Random:NormMode=NumEvents:!V",
+            float sig_ratio=0.7,
+            float bkg_ratio=0.7) {
+  TString opt_t = "nTrain_Signal="+std::to_string(int(sigTrain->Draw("",cut_sig,"")*sig_ratio))+":nTrain_Background="+std::to_string(int(bkgTrain->Draw("",cut_bkg,"")*bkg_ratio))+":"+opt;
   addHadVariablePP(dataloader);
   addTree(dataloader, sigTrain, sigTest, bkgTrain, bkgTest, signalWeight, backgroundWeight);
-  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt );
+  dataloader->PrepareTrainingAndTestTree(cut_sig, cut_bkg, opt_t );
   addMethod(Use, factory, dataloader);
 }
 
@@ -202,7 +221,7 @@ int vts_dR_04_Jet( TString myMethodList = "" )
   Use["TMlpANN"]         = 0; // ROOT's own ANN
   // Boosted Decision Trees
   Use["BDT"]             = 1; // uses Adaptive Boost
-  Use["BDTG"]            = 1; // uses Gradient Boost
+  Use["BDTG"]            = 0; // uses Gradient Boost
 
   std::map<std::string, int> Opt;
 
@@ -244,29 +263,29 @@ int vts_dR_04_Jet( TString myMethodList = "" )
 //  TString sample_bsbar_pythia = "/xrootd/store/user/wjjang/test/sum_tt012j/bsbar_pythia.root";
 //  TString sample_bsbar_herwig = "/xrootd/store/user/wjjang/test/sum_tt012j/bsbar_herwig.root";
 
-  TString sample_bbars_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bbars_2l_FxFx_sum_630_combined.root";
-  TString sample_bsbar_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bsbar_2l_FxFx_sum_774_combined.root";
-  TString sample_bbbar_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bbbar_2l_FxFx_sum_201.root";
-  TString sample_bbars_bsbar_pythia       = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bbars_bsbar_sum_630_774_combined.root";
-  TString sample_bbars_bsbar_bbbar_pythia = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bbars_bsbar_bbbar_sum_630_774_201_combined.root";
+  TString sample_bbars_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190305/tt012j_bbars_2l_FxFx_sum_630_combined.root";
+  TString sample_bsbar_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190305/tt012j_bsbar_2l_FxFx_sum_774_combined.root";
+  TString sample_bbbar_pythia             = "/xrootd/store/user/wjjang/test/sum_tt012j/20190305/tt012j_bbbar_2l_FxFx_sum_201.root";
+  TString sample_bbars_bsbar_pythia       = "/xrootd/store/user/wjjang/test/sum_tt012j/20190305/tt012j_bbars_bsbar_sum_630_774_combined.root";
+  TString sample_bbars_bsbar_bbbar_pythia = "/xrootd/store/user/wjjang/test/sum_tt012j/20190305/tt012j_bbars_bsbar_bbbar_sum_630_774_201_combined.root";
 
-  TString sample_bbars_herwig       = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bbars_2l_FxFx_herwigpp_sum_49.root";
-  TString sample_bsbar_herwig       = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bsbar_2l_FxFx_herwigpp_sum_49.root";
-  TString sample_bbars_bsbar_herwig = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bbars_bsbar_herwigpp_sum_49_49.root";
+//  TString sample_bbars_herwig       = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bbars_2l_FxFx_herwigpp_sum_49.root";
+//  TString sample_bsbar_herwig       = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bsbar_2l_FxFx_herwigpp_sum_49.root";
+//  TString sample_bbars_bsbar_herwig = "/xrootd/store/user/wjjang/test/sum_tt012j/20190105/tt012j_bbars_bsbar_herwigpp_sum_49_49.root";
 
-  bbars_pythia = TFile::Open( sample_bbars_pythia );             bbars_herwig = TFile::Open( sample_bbars_herwig );
-  bsbar_pythia = TFile::Open( sample_bsbar_pythia );             bsbar_herwig = TFile::Open( sample_bsbar_herwig );
+  bbars_pythia = TFile::Open( sample_bbars_pythia );           //  bbars_herwig = TFile::Open( sample_bbars_herwig );
+  bsbar_pythia = TFile::Open( sample_bsbar_pythia );           //  bsbar_herwig = TFile::Open( sample_bsbar_herwig );
   bbbar_pythia = TFile::Open( sample_bbbar_pythia );
-  bbars_bsbar_pythia = TFile::Open( sample_bbars_bsbar_pythia ); bbars_bsbar_herwig = TFile::Open( sample_bbars_bsbar_herwig );
+  bbars_bsbar_pythia = TFile::Open( sample_bbars_bsbar_pythia ); //bbars_bsbar_herwig = TFile::Open( sample_bbars_bsbar_herwig );
   bbars_bsbar_bbbar_pythia = TFile::Open( sample_bbars_bsbar_bbbar_pythia );
 
   std::cout << "--- vts_dR_04_Jet       : Using input file 1 : " << bbars_pythia->GetName() << std::endl;
-  std::cout << "--- vts_dR_04_Jet       : Using input file 2 : " << bbars_herwig->GetName() << std::endl;
+//  std::cout << "--- vts_dR_04_Jet       : Using input file 2 : " << bbars_herwig->GetName() << std::endl;
   std::cout << "--- vts_dR_04_Jet       : Using input file 3 : " << bsbar_pythia->GetName() << std::endl;
-  std::cout << "--- vts_dR_04_Jet       : Using input file 4 : " << bsbar_herwig->GetName() << std::endl;
+//  std::cout << "--- vts_dR_04_Jet       : Using input file 4 : " << bsbar_herwig->GetName() << std::endl;
   std::cout << "--- vts_dR_04_Jet       : Using input file 5 : " << bbbar_pythia->GetName() << std::endl;
   std::cout << "--- vts_dR_04_Jet       : Using input file 6 : " << bbars_bsbar_pythia->GetName() << std::endl;
-  std::cout << "--- vts_dR_04_Jet       : Using input file 7 : " << bbars_bsbar_herwig->GetName() << std::endl;
+//  std::cout << "--- vts_dR_04_Jet       : Using input file 7 : " << bbars_bsbar_herwig->GetName() << std::endl;
   std::cout << "--- vts_dR_04_Jet       : Using input file 8 : " << bbars_bsbar_bbbar_pythia->GetName() << std::endl;
 
   // Register the training and test trees
@@ -276,9 +295,9 @@ int vts_dR_04_Jet( TString myMethodList = "" )
   TTree *bbars_bsbar_pythia_tree     = (TTree*)bbars_bsbar_pythia->Get("MVA_jet");
   TTree *bbars_bsbar_bbbar_pythia_tree     = (TTree*)bbars_bsbar_bbbar_pythia->Get("MVA_jet");
   
-  TTree *bbars_herwig_tree           = (TTree*)bbars_herwig->Get("MVA_jet");
-  TTree *bsbar_herwig_tree           = (TTree*)bsbar_herwig->Get("MVA_jet");
-  TTree *bbars_bsbar_herwig_tree     = (TTree*)bbars_bsbar_herwig->Get("MVA_jet");
+//  TTree *bbars_herwig_tree           = (TTree*)bbars_herwig->Get("MVA_jet");
+//  TTree *bsbar_herwig_tree           = (TTree*)bsbar_herwig->Get("MVA_jet");
+//  TTree *bbars_bsbar_herwig_tree     = (TTree*)bbars_bsbar_herwig->Get("MVA_jet");
 
   // Create a ROOT output file where TMVA will store ntuples, histograms, etc.
   TString outfileName( "./output/vts_dR_04_Jet.root" );
@@ -346,136 +365,81 @@ int vts_dR_04_Jet( TString myMethodList = "" )
   // global event weights per tree (see below for setting event-wise weights) 
      Double_t signalWeight     = 1.0; Double_t backgroundWeight = 1.0;
 
-  /* Cuts for JKS >>>> KS_best_bdt >= 0.0783 : jet includes Real KS || 20181120 bbars_bsbar_bbbar sample*/ 
-  TCut cut_JKS_BDT_s_highest   = "isHighest && KS_idx != -99 && KS_best_bdt >= 0.0783 && isSJet && !isBJet";
-  TCut cut_JKS_BDT_b_highest   = "isHighest && KS_idx != -99 && KS_best_bdt >= 0.0783 && isBJet && !isSJet";
-  TCut cut_JKS_BDT_all_highest = "isHighest && KS_idx != -99 && KS_best_bdt >= 0.0783 && !isSJet";
+  /* Cuts for JKS >>>> Ks_bdt_score >= 0.0885 : jet includes Real KS || 20190304 bbars_bsbar_bbbar sample*/ 
+  TCut cut_JKS_BDT_s_highest   = "isHighest && Ks_bdt_score >= 0.0885 && isSJet";
+  TCut cut_JKS_BDT_b_highest   = "isHighest && Ks_bdt_score >= 0.0885 && isBJet";
+  TCut cut_JKS_BDT_all_highest = "isHighest && Ks_bdt_score >= 0.0885 && !isSJet";
 
-  TCut cut_JKS_BDT_s_closest   = "isClosestToLep && KS_idx != -99 && KS_best_bdt >= 0.0783 && isSJet && !isBJet";
-  TCut cut_JKS_BDT_b_closest   = "isClosestToLep && KS_idx != -99 && KS_best_bdt >= 0.0783 && isBJet && !isSJet";
-  TCut cut_JKS_BDT_all_closest = "isClosestToLep && KS_idx != -99 && KS_best_bdt >= 0.0783 && !isSJet";
+  TCut cut_JKS_BDT_s_closest   = "isClosestToLep && Ks_bdt_score >= 0.0885 && isSJet";
+  TCut cut_JKS_BDT_b_closest   = "isClosestToLep && Ks_bdt_score >= 0.0885 && isBJet";
+  TCut cut_JKS_BDT_all_closest = "isClosestToLep && Ks_bdt_score >= 0.0885 && !isSJet";
 
-  TCut cut_JKS_BDT_s_highBDT   = "isHighBDT && KS_idx != -99 && KS_best_bdt >= 0.0783 && isSJet && !isBJet";
-  TCut cut_JKS_BDT_b_highBDT   = "isHighBDT && KS_idx != -99 && KS_best_bdt >= 0.0783 && isBJet && !isSJet";
-  TCut cut_JKS_BDT_all_highBDT = "isHighBDT && KS_idx != -99 && KS_best_bdt >= 0.0783 && !isSJet";
+  TCut cut_JKS_BDT_s_highBDT   = "isHighBDT && Ks_bdt_score >= 0.0885 && isSJet";
+  TCut cut_JKS_BDT_b_highBDT   = "isHighBDT && Ks_bdt_score >= 0.0885 && isBJet";
+  TCut cut_JKS_BDT_all_highBDT = "isHighBDT && Ks_bdt_score >= 0.0885 && !isSJet";
 
-  TCut cut_JKS_BDT_s           = "KS_idx != -99 && KS_best_bdt >= 0.0783 && isSJet && !isBJet";
-  TCut cut_JKS_BDT_b           = "KS_idx != -99 && KS_best_bdt >= 0.0783 && isBJet && !isSJet";
-  TCut cut_JKS_BDT_all         = "KS_idx != -99 && KS_best_bdt >= 0.0783 && !isSJet";
+  TCut cut_JKS_BDT_s           = "Ks_bdt_score >= 0.0885 && isSJet";
+  TCut cut_JKS_BDT_b           = "Ks_bdt_score >= 0.0885 && isBJet";
+  TCut cut_JKS_BDT_all         = "Ks_bdt_score >= 0.0885 && !isSJet";
 
-  /* Cuts for J >>>> KS_best_bdt < 0.0783 : jet includes Fake KS | KS_idx == -99 : KS isn't in the jet or there is no KS in a event */ 
-  TCut cut_J_BDT_s_highest   = "isHighest && (KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && isSJet && !isBJet";
-  TCut cut_J_BDT_b_highest   = "isHighest && (KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && isBJet && !isSJet";
-  TCut cut_J_BDT_all_highest = "isHighest && (KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && !isSJet";
+  /* Cuts for J >>>> Ks_bdt_score < 0.0885 : jet includes Fake KS */ 
+  TCut cut_J_BDT_s_highest   = "isHighest && Ks_bdt_score < 0.0885 && isSJet";
+  TCut cut_J_BDT_b_highest   = "isHighest && Ks_bdt_score < 0.0885 && isBJet";
+  TCut cut_J_BDT_all_highest = "isHighest && Ks_bdt_score < 0.0885 && !isSJet";
 
-  TCut cut_J_BDT_s_closest   = "isClosestToLep && (KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && isSJet && !isBJet";
-  TCut cut_J_BDT_b_closest   = "isClosestToLep && (KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && isBJet && !isSJet";
-  TCut cut_J_BDT_all_closest = "isClosestToLep && (KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && !isSJet";
+  TCut cut_J_BDT_s_closest   = "isClosestToLep && Ks_bdt_score < 0.0885 && isSJet";
+  TCut cut_J_BDT_b_closest   = "isClosestToLep && Ks_bdt_score < 0.0885 && isBJet";
+  TCut cut_J_BDT_all_closest = "isClosestToLep && Ks_bdt_score < 0.0885 && !isSJet";
 
-  TCut cut_J_BDT_s_highBDT   = "isHighBDT && (KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && isSJet && !isBJet";
-  TCut cut_J_BDT_b_highBDT   = "isHighBDT && (KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && isBJet && !isSJet";
-  TCut cut_J_BDT_all_highBDT = "isHighBDT && (KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && !isSJet";
+  TCut cut_J_BDT_s_highBDT   = "isHighBDT && Ks_bdt_score < 0.0885 && isSJet";
+  TCut cut_J_BDT_b_highBDT   = "isHighBDT && Ks_bdt_score < 0.0885 && isBJet";
+  TCut cut_J_BDT_all_highBDT = "isHighBDT && Ks_bdt_score < 0.0885 && !isSJet";
 
-  TCut cut_J_BDT_s           = "(KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && isSJet && !isBJet";
-  TCut cut_J_BDT_b           = "(KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && isBJet && !isSJet";
-  TCut cut_J_BDT_all         = "(KS_idx == -99 || ( KS_best_bdt >= -1. && KS_best_bdt < 0.0783 ) ) && !isSJet";
+  TCut cut_J_BDT_s           = "Ks_bdt_score < 0.0885 && isSJet";
+  TCut cut_J_BDT_b           = "Ks_bdt_score < 0.0885 && isBJet";
+  TCut cut_J_BDT_all         = "Ks_bdt_score < 0.0885 && !isSJet";
 
-  TCut cut_s_highest   = "isHighest && isSJet && !isBJet";
-  TCut cut_b_highest   = "isHighest && isBJet && !isSJet";
+  TCut cut_s_highest   = "isHighest && isSJet";
+  TCut cut_b_highest   = "isHighest && isBJet";
   TCut cut_non_highest = "isHighest && !isSJet && !isBJet";
   TCut cut_all_highest = "isHighest && !isSJet";
 
-  TCut cut_s_closest   = "isClosestToLep && isSJet && !isBJet";
-  TCut cut_b_closest   = "isClosestToLep && isBJet && !isSJet";
+  TCut cut_s_closest   = "isClosestToLep && isSJet";
+  TCut cut_b_closest   = "isClosestToLep && isBJet";
   TCut cut_non_closest = "isClosestToLep && !isSJet && !isBJet";
   TCut cut_all_closest = "isClosestToLep && !isSJet";
 
-  TCut cut_s_highBDT   = "isHighBDT && isSJet && !isBJet";
-  TCut cut_b_highBDT   = "isHighBDT && isBJet && !isSJet";
+  TCut cut_s_highBDT   = "isHighBDT && isSJet";
+  TCut cut_b_highBDT   = "isHighBDT && isBJet";
   TCut cut_non_highBDT = "isHighBDT && !isSJet && !isBJet";
   TCut cut_all_highBDT = "isHighBDT && !isSJet";
 
-  TCut cut_s           = "isSJet && !isBJet";
-  TCut cut_b           = "isBJet && !isSJet";
+  TCut cut_s           = "isSJet";
+  TCut cut_b           = "isBJet";
   TCut cut_all         = "!isSJet";
 
-  /* for 20181120 bbars_bsbar_bbbar samples ratio of train/test is about 7:3 */
-  TString opt_JKS_BDT_nocondi  = "nTrain_Signal=3100:nTrain_Background=78000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_JKS_BDT_highest  = "nTrain_Signal=2350:nTrain_Background=6000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_JKS_BDT_closest  = "nTrain_Signal=2200:nTrain_Background=5000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_JKS_BDT_highBDT  = "nTrain_Signal=2530:nTrain_Background=6000:SplitMode=Random:NormMode=NumEvents:!V";
-
-  TString opt_JKS_BDT_bnocondi = "nTrain_Signal=3100:nTrain_Background=37000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_JKS_BDT_bhighest = "nTrain_Signal=2350:nTrain_Background=3500:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_JKS_BDT_bclosest = "nTrain_Signal=2200:nTrain_Background=3000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_JKS_BDT_bhighBDT = "nTrain_Signal=2530:nTrain_Background=3700:SplitMode=Random:NormMode=NumEvents:!V";
-
-  TString opt_J_BDT_nocondi    = "nTrain_Signal=70000:nTrain_Background=1700000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_J_BDT_highest    = "nTrain_Signal=58500:nTrain_Background=125000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_J_BDT_closest    = "nTrain_Signal=51000:nTrain_Background=100000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_J_BDT_highBDT    = "nTrain_Signal=63500:nTrain_Background=120000:SplitMode=Random:NormMode=NumEvents:!V";
-
-  TString opt_J_BDT_bnocondi   = "nTrain_Signal=70000:nTrain_Background=680000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_J_BDT_bhighest   = "nTrain_Signal=58500:nTrain_Background=65000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_J_BDT_bclosest   = "nTrain_Signal=51000:nTrain_Background=58000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_J_BDT_bhighBDT   = "nTrain_Signal=63500:nTrain_Background=70000:SplitMode=Random:NormMode=NumEvents:!V";
-
-  TString opt_all_BDT_highest  = "nTrain_Signal=61000:nTrain_Background=130000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_all_BDT_highBDT  = "nTrain_Signal=66000:nTrain_Background=125000:SplitMode=Random:NormMode=NumEvents:!V";
-
-  TString opt_all_BDT_bhighest = "nTrain_Signal=61000:nTrain_Background=68000:SplitMode=Random:NormMode=NumEvents:!V";
-  TString opt_all_BDT_bhighBDT = "nTrain_Signal=66000:nTrain_Background=74000:SplitMode=Random:NormMode=NumEvents:!V";
-
   /* JKS Events */
-  setJKS(Use, factory, pp_combined_JKS_BDT_highest, bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_all_highest, opt_JKS_BDT_highest);
-  setJKS(Use, factory, pp_combined_JKS_BDT_closest, bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_closest, cut_JKS_BDT_all_closest, opt_JKS_BDT_closest);
-  setJKS(Use, factory, pp_combined_JKS_BDT_highBDT, bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highBDT, cut_JKS_BDT_all_highBDT, opt_JKS_BDT_highBDT);
-
-  setJKS(Use, factory, pp_s_vs_b_JKS_BDT_highest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_b_highest,   opt_JKS_BDT_bhighest);
-  setJKS(Use, factory, pp_s_vs_b_JKS_BDT_closest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_closest, cut_JKS_BDT_b_closest,   opt_JKS_BDT_bclosest);
-  setJKS(Use, factory, pp_s_vs_b_JKS_BDT_highBDT,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highBDT, cut_JKS_BDT_b_highBDT,   opt_JKS_BDT_bhighBDT);
-
+  setJKS(Use, factory, pp_combined_JKS_BDT_highest, bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_all_highest);
+  setJKS(Use, factory, pp_combined_JKS_BDT_closest, bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_closest, cut_JKS_BDT_all_closest);
+  setJKS(Use, factory, pp_s_vs_b_JKS_BDT_highest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_b_highest);
+  setJKS(Use, factory, pp_s_vs_b_JKS_BDT_closest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_closest, cut_JKS_BDT_b_closest);
   /* JKS Events wo KS */
-  setJ(  Use, factory, JKS_wo_KS_highest,           bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_all_highest, opt_JKS_BDT_highest);
-  setJ(  Use, factory, JKS_wo_KS_highBDT,           bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highBDT, cut_JKS_BDT_all_highBDT, opt_JKS_BDT_highBDT);
-
-  setJ(  Use, factory, JKS_wo_KS_s_vs_b_highest,    bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_b_highest,   opt_JKS_BDT_bhighest);
-  setJ(  Use, factory, JKS_wo_KS_s_vs_b_highBDT,    bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highBDT, cut_JKS_BDT_b_highBDT,   opt_JKS_BDT_bhighBDT);
-
+  setJ(  Use, factory, JKS_wo_KS_highest,           bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_all_highest);
+  setJ(  Use, factory, JKS_wo_KS_s_vs_b_highest,    bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_b_highest);
   /* JKS Events wo Jet */
-  setHad(Use, factory, JKS_wo_Jet_highest,          bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_all_highest, opt_JKS_BDT_highest);
-  setHad(Use, factory, JKS_wo_Jet_highBDT,          bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highBDT, cut_JKS_BDT_all_highBDT, opt_JKS_BDT_highBDT);
-
-  setHad(Use, factory, JKS_wo_Jet_s_vs_b_highest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_b_highest,   opt_JKS_BDT_bhighest);
-  setHad(Use, factory, JKS_wo_Jet_s_vs_b_highBDT,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highBDT, cut_JKS_BDT_b_highBDT,   opt_JKS_BDT_bhighBDT);
-
+  setHad(Use, factory, JKS_wo_Jet_highest,          bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_all_highest);
+  setHad(Use, factory, JKS_wo_Jet_s_vs_b_highest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s_highest, cut_JKS_BDT_b_highest);
   /* Jet Events */
-  setJ(  Use, factory, pp_combined_J_BDT_highest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_highest,   cut_J_BDT_all_highest,   opt_J_BDT_highest);
-  setJ(  Use, factory, pp_combined_J_BDT_closest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_closest,   cut_J_BDT_all_closest,   opt_J_BDT_closest);
-  setJ(  Use, factory, pp_combined_J_BDT_highBDT,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_highBDT,   cut_J_BDT_all_highBDT,   opt_J_BDT_highBDT);
-
-  setJ(  Use, factory, pp_s_vs_b_J_BDT_highest,     bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_highest,   cut_J_BDT_b_highest,     opt_J_BDT_bhighest);
-  setJ(  Use, factory, pp_s_vs_b_J_BDT_closest,     bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_closest,   cut_J_BDT_b_closest,     opt_J_BDT_bclosest);
-  setJ(  Use, factory, pp_s_vs_b_J_BDT_highBDT,     bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_highBDT,   cut_J_BDT_b_highBDT,     opt_J_BDT_bhighBDT);
-
+  setJ(  Use, factory, pp_combined_J_BDT_highest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_highest,   cut_J_BDT_all_highest);
+  setJ(  Use, factory, pp_combined_J_BDT_closest,   bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_closest,   cut_J_BDT_all_closest);
+  setJ(  Use, factory, pp_s_vs_b_J_BDT_highest,     bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_highest,   cut_J_BDT_b_highest);
+  setJ(  Use, factory, pp_s_vs_b_J_BDT_closest,     bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s_closest,   cut_J_BDT_b_closest);
   /* All Events */
-  setJKS(Use, factory, all_highest,                 bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highest,         cut_all_highest,         opt_all_BDT_highest);
-  setJKS(Use, factory, all_highBDT,                 bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highBDT,         cut_all_highBDT,         opt_all_BDT_highBDT);
-  
-  setJKS(Use, factory, all_s_vs_b_highest,          bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highest,         cut_b_highest,           opt_all_BDT_bhighest);
-  setJKS(Use, factory, all_s_vs_b_highBDT,          bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highBDT,         cut_b_highBDT,           opt_all_BDT_bhighBDT);
-
+  setJKS(Use, factory, all_highest,                 bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highest,         cut_all_highest);
+  setJKS(Use, factory, all_s_vs_b_highest,          bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highest,         cut_b_highest);
   /* All Events wo KS */
-  setJ(  Use, factory, all_wo_KS_highest,           bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highest,         cut_all_highest,         opt_all_BDT_highest);
-  setJ(  Use, factory, all_wo_KS_highBDT,           bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highBDT,         cut_all_highBDT,         opt_all_BDT_highBDT);
-
-  setJ(  Use, factory, all_wo_KS_s_vs_b_highest,    bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highest,         cut_b_highest,           opt_all_BDT_bhighest);
-  setJ(  Use, factory, all_wo_KS_s_vs_b_highBDT,    bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highBDT,         cut_b_highBDT,           opt_all_BDT_bhighBDT);
-
-//  setJKS(Use, factory, pp_combined_JKS_BDT, bbars_bsbar_pythia_tree, bbars_bsbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s, cut_JKS_BDT_all, opt_JKS_BDT_nocondi);
-//  setJKS(Use, factory, pp_s_vs_b_JKS_BDT,   bbars_bsbar_pythia_tree, bbars_bsbar_pythia_tree, signalWeight, backgroundWeight, cut_JKS_BDT_s, cut_JKS_BDT_b,   opt_JKS_BDT_bnocondi);
-//  setJ(  Use, factory, pp_combined_J_BDT,   bbars_bsbar_pythia_tree, bbars_bsbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s,   cut_J_BDT_all,   opt_J_BDT_nocondi);
-//  setJ(  Use, factory, pp_s_vs_b_J_BDT,     bbars_bsbar_pythia_tree, bbars_bsbar_pythia_tree, signalWeight, backgroundWeight, cut_J_BDT_s,   cut_J_BDT_b,     opt_J_BDT_bnocondi);
+  setJ(  Use, factory, all_wo_KS_highest,           bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highest,         cut_all_highest);
+  setJ(  Use, factory, all_wo_KS_s_vs_b_highest,    bbars_bsbar_bbbar_pythia_tree, bbars_bsbar_bbbar_pythia_tree, signalWeight, backgroundWeight, cut_s_highest,         cut_b_highest);
 
   // For an example of the category classifier usage, see: vts_dR_04_JetCategory
   //


### PR DESCRIPTION
1. Fix bug in vtsAnalyser (
    a. skip wrong HADTRUTHAOD in dj's tt012j_bbars   
    b. skip FillTMVATrees() when there are no m_jetDeltaRs to avoid segment fault 
    c. give all selected jets label of isClosestToLep
2. Fix bug in Event_2016v4 (~Event())
3. Minor change of tmva code